### PR TITLE
feat: Create payment method on frontend instead of BE

### DIFF
--- a/src/webapp/src/accounts/services/accounts.service.spec.ts
+++ b/src/webapp/src/accounts/services/accounts.service.spec.ts
@@ -33,13 +33,38 @@ describe('Accounts Service', () => {
 
   let user: UserEntity
 
+  enum AccountIds {
+    EXISTING_ACCOUNT=1,
+    EXISTING_ACCOUNT_WITH_PAYMENT_METHODS=2,
+    ACCOUNT_NOT_FOUND=404,
+    MALFORMED_ACCOUNT=500
+  }
+
   const mockedRepo = {
     find: jest.fn().mockResolvedValue(accountsArray),
     createOne: jest.fn(account => account),
     findById: jest.fn(id => {
       const account = new AccountEntity()
       account.id = id
-      return account
+
+      switch (id) {
+        case AccountIds.EXISTING_ACCOUNT_WITH_PAYMENT_METHODS:
+          account.data = {
+            payments_methods: [{ id: 'payment_method' }, { id: 'payment_method 2' }],
+            stripe: { id: 'cus_123' }
+          }
+          return account
+        case AccountIds.ACCOUNT_NOT_FOUND:
+          return undefined
+        case AccountIds.MALFORMED_ACCOUNT:
+          account.data = null
+          return account
+        default:
+          account.data = {
+            stripe: { id: 'cus_123' }
+          }
+          return account
+      }
     }),
     updateOne: jest.fn((id, account) => account)
   }
@@ -62,10 +87,15 @@ describe('Accounts Service', () => {
   // This depends on Stripe. We need to update this when we support more payment processors
   const mockedPaymentsService = {
     createStripeCustomer: jest.fn(_ => {}),
-    createStripeFreeSubscription: jest.fn(_ => {})
+    createStripeFreeSubscription: jest.fn(_ => {}),
+    attachPaymentMethod: jest.fn((customer, _) => customer),
+    subscribeToPlan: jest.fn(_ => {})
   }
 
-  const mockedPlansService = { getPlans: jest.fn(_ => [{}]) }
+  const mockedPlansService = {
+    getPlans: jest.fn(_ => [{}]),
+    getPriceByProductAndAnnual: jest.fn(_ => ({ plan: '1' }))
+  }
 
   beforeEach(async () => {
     jest.clearAllMocks()
@@ -268,6 +298,71 @@ describe('Accounts Service', () => {
 
           expect(invitedUser.data.resetPasswordToken).toBeUndefined()
           expect(invitedUser.data.resetPasswordTokenExp).toBeUndefined()
+        })
+      })
+    })
+
+    describe('Subscriptions', () => {
+      describe('Add payments methods', () => {
+        it('Should return error if account is not found', async () => {
+          // const repoSpy = jest.spyOn(mockedUserRepo, 'findOrCreateUser')
+          const res = await service.addPaymentsMethods(AccountIds.ACCOUNT_NOT_FOUND)
+
+          expect(res).toBeNull()
+        })
+
+        it('Should return error if account is malformed', async () => {
+          // const repoSpy = jest.spyOn(mockedUserRepo, 'findOrCreateUser')
+          const res = await service.addPaymentsMethods(AccountIds.MALFORMED_ACCOUNT)
+
+          expect(res).toBeNull()
+        })
+
+        it('Should call the attachPaymentMethod method of paymentsService', async () => {
+          const repoSpy = jest.spyOn(mockedPaymentsService, 'attachPaymentMethod')
+          const res = await service.addPaymentsMethods(AccountIds.EXISTING_ACCOUNT, { id: 'payment_method' })
+
+          expect(res).not.toBeNull()
+          expect(repoSpy).toBeCalledTimes(1)
+        })
+
+        it('Should add a payment method if the account does not yet have any payment method', async () => {
+          const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
+          await service.addPaymentsMethods(AccountIds.EXISTING_ACCOUNT, { id: 'payment_method' })
+
+          expect(repoSpy).toBeCalledWith(
+            AccountIds.EXISTING_ACCOUNT,
+            expect.objectContaining({
+              data: { payments_methods: [{ id: 'payment_method' }], stripe: { id: 'cus_123' } }
+            })
+          )
+        })
+
+        it('Should append a payment method if the account already has a payment method', async () => {
+          const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
+          await service.addPaymentsMethods(AccountIds.EXISTING_ACCOUNT_WITH_PAYMENT_METHODS, { id: 'payment_method 3' })
+
+          expect(repoSpy).toBeCalledWith(
+            AccountIds.EXISTING_ACCOUNT_WITH_PAYMENT_METHODS,
+            expect.objectContaining({
+              data: { payments_methods: [{ id: 'payment_method' }, { id: 'payment_method 2' }, { id: 'payment_method 3' }], stripe: { id: 'cus_123' } }
+            })
+          )
+        })
+      })
+
+      describe('Subscribe to plan', () => {
+        it('Should be possible to subscribe to plan choosing a payment method', async () => {
+          const repoSpy = jest.spyOn(mockedPaymentsService, 'subscribeToPlan')
+          const account = mockedRepo.findById(AccountIds.EXISTING_ACCOUNT_WITH_PAYMENT_METHODS)
+
+          await service.subscribeToPlan(account, { method: 'payment_method 2' })
+
+          expect(repoSpy).toBeCalledWith(
+            account?.data?.stripe?.id,
+            { id: 'payment_method 2' },
+            { plan: '1' }
+          )
         })
       })
     })

--- a/src/webapp/src/api/controllers/v1/api.payment.controller.ts
+++ b/src/webapp/src/api/controllers/v1/api.payment.controller.ts
@@ -40,4 +40,24 @@ export class ApiV1PaymentController {
       message: subscription
     })
   }
+
+  @UseGuards(UserRequiredAuthGuard)
+  @Post('add-payment-token')
+  async handleAddPaymentToken (@Request() req, @Res() res: Response): Promise<any> {
+    const account = await this.accountsService.findByOwnerEmail(req.user.email)
+
+    if (account == null) {
+      return res.json({
+        statusCode: 400,
+        error: 'Account not found'
+      })
+    }
+
+    const methods = await this.accountsService.addPaymentsMethods(account.id, req.body)
+
+    return res.json({
+      statusCode: 200,
+      message: methods
+    })
+  }
 }

--- a/src/webapp/src/payments/services/payments.service.ts
+++ b/src/webapp/src/payments/services/payments.service.ts
@@ -210,4 +210,38 @@ export class PaymentsService extends BaseService<PaymentEntity> {
       return null
     }
   };
+
+  /**
+   * Attach a payment method to a Stripe customer and sets as default.
+   * The payment method must already be created before calling this function.
+   * @param customer id of the Stripe customer
+   * @param method id of the payment method
+   */
+  async attachPaymentMethod (customer: string, method: string): Promise<any|null> {
+    try {
+      await this.stripeService.client.paymentMethods.attach(method, {
+        customer
+      })
+    } catch (error) {
+      console.error('paymentsService - attachPaymentMethod - error while attaching')
+      return null
+    }
+
+    try {
+      // Change the default invoice settings on the customer to the new payment method
+      const updatedCustomer = await this.stripeService.client.customers.update(
+        customer,
+        {
+          invoice_settings: {
+            default_payment_method: method
+          }
+        }
+      )
+
+      return updatedCustomer
+    } catch (error) {
+      console.error('paymentsService - attachPaymentMethod - error while setting default payment method')
+      return null
+    }
+  }
 }

--- a/src/webapp/src/website/controllers/payments.controller.ts
+++ b/src/webapp/src/website/controllers/payments.controller.ts
@@ -34,9 +34,10 @@ export class PaymentsController {
   @UseGuards(UserRequiredAuthGuard)
   @Post('/user/billing/payment')
   async newPaymentMethod (@Request() req, @Res() res: Response): Promise<any> {
+    // DEPRECATED, see https://stripe.com/docs/payments/accept-a-payment-charges#web-create-token
     const account = await this.accountsService.findByOwnerEmail(req.user.email)
 
-    await this.accountsService.addPaymentsMethods(account.id, req.body)
+    await this.accountsService.createPaymentsMethods(account.id, req.body)
 
     return res.redirect('/user/billing/subscribe')
   }

--- a/src/webapp/src/website/controllers/user.controller.ts
+++ b/src/webapp/src/website/controllers/user.controller.ts
@@ -71,7 +71,7 @@ export class UserController {
   async getUserBilling (@Request() req, @Res() res: Response): Promise<any> {
     const account = await this.accountsService.findByOwnerEmail(req.user.email)
     return renderUserPage(req, res, 'billing', {
-      account,
+      account
     })
   }
 }

--- a/src/webapp/src/website/utilities/render.ts
+++ b/src/webapp/src/website/utilities/render.ts
@@ -32,7 +32,7 @@ const renderUserPage = (req, res, page: string, data = {} as any): Response => {
   const userPageData = {
     user_page: page,
     // important - we must guarantee that payment_methods is an array
-    payment_methods: data?.account?.payments_methods ?? [],
+    payment_methods: data?.account?.payments_methods ?? []
   }
   return renderPage(req, res, 'user', userPageData)
 }

--- a/src/webapp/themes/bare/assets/stripe.js
+++ b/src/webapp/themes/bare/assets/stripe.js
@@ -81,6 +81,34 @@ function handlePaymentThatRequiresCustomerAction({
     completed_cb(result);
   }
 
+
+  // Create a token or display an error when the form is submitted.
+
+function createPaymentToken(_csrf) {
+  stripe.createToken(card).then(function(result) {
+    if (result.error) {
+      // Inform the customer that there was an error.
+      var errorElement = document.getElementById('card-errors');
+      errorElement.textContent = result.error.message;
+    } else {
+      // Send the token to your server.
+      // stripeTokenHandler(result.token);
+      console.log('token', result.token)
+      fetch('/api/v1/add-payment-token', {
+        method: 'post',
+        headers: {
+          'Content-type': 'application/json',
+          'CSRF-Token': _csrf // <-- is the csrf token as a header
+        },
+        body: JSON.stringify({
+            plan, method, monthly
+        }),
+      })
+
+    }
+  });
+}
+
 function createSubscription({ plan, method, monthly, _csrf }, completed_cb, error_cb) {
     return (
       fetch('/api/v1/create-subscription', {

--- a/src/webapp/themes/bare/subscribe.liquid
+++ b/src/webapp/themes/bare/subscribe.liquid
@@ -5,9 +5,24 @@
   <script>
     // This will create stipe client needed to perform 3dS checks.
     // Please, copy exacly this way
-    let  stripe = Stripe("{{stripePublishableKey}}");
+    const  stripe = Stripe("{{stripePublishableKey}}");
+    const elements = stripe.elements();
   </script>
   <script type="module">
+    // Custom styling can be passed to options when creating an Element.
+    var style = {
+      base: {
+        // Add your base input styles here. For example:
+        fontSize: '16px',
+      },
+    };
+
+    // Create an instance of the card Element.
+    var card = elements.create('card', {style});
+
+    // Add an instance of the card Element into the `card-element` <div>.
+    card.mount('#card-element');
+
     // This is where your scripr might change. It must fetch from your page
     // the plan id and the payment method id. In addition it can accept a monthly flag
     // to indicate that the monthly payment is required.
@@ -16,9 +31,8 @@
     // 1. Attaching a listener to the form submit event
     const paymentForm = document.getElementById('payment-form');
     if (paymentForm) {
-      paymentForm.addEventListener('submit', function (evt) {
-        // We will handle the submit ourself
-        evt.preventDefault();
+      paymentForm.addEventListener('submit', function (event) {
+        event.preventDefault();
 
         // Getting value out of form.
         const data = new FormData(document.getElementById('payment-form'));
@@ -42,8 +56,55 @@
           alert('Choose a plan and a payment method')
       });
     }
+
+
+    const paymentMethodForm = document.getElementById('payment-method');
+    if (paymentMethodForm) {
+      // Create a token or display an error when the form is submitted.
+      paymentMethodForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+
+        // stripe.createToken(card)
+        stripe
+        .createPaymentMethod({
+          type: 'card',
+          card: card,
+          // billing_details: {
+            // name: billingName,
+          // },
+        })
+        .then(function(result) {
+          if (result.error) {
+            // Inform the customer that there was an error.
+            var errorElement = document.getElementById('card-errors');
+            errorElement.textContent = result.error.message;
+          } else {
+            // Send the token to your server.
+            // stripeTokenHandler(result.token);
+            console.log('card', result)
+            fetch('/api/v1/add-payment-token', {
+              method: 'post',
+              headers: {
+                'Content-type': 'application/json',
+                'CSRF-Token': _csrf // <-- is the csrf token as a header
+              },
+              body: JSON.stringify({
+                ...result.paymentMethod
+              }),
+            })
+              .then((response) => {
+                console.log(response.json());
+                
+              })
+
+          }
+        });
+      });
+
+    }
   </script>
-</head><body>
+</head>
+<body>
 
 <h1>Subscribe to plan</h1>
 
@@ -97,21 +158,21 @@
 <div>
   <h2>Add a payment method</h2>
 
-  <form action="/user/billing/payment" method="POST">
+  <form id="payment-method">
+  <div class="form-row">
+    <label for="card-element">
+      Credit or debit card
+    </label>
+    <div id="card-element">
+      <!-- A Stripe Element will be inserted here. -->
+    </div>
 
-    <!-- Name -->
-    <input name="paymentName" id="modalPaymentName" type="text" value="First Last">
+    <!-- Used to display Element errors. -->
+    <div id="card-errors" role="alert"></div>
+  </div>
 
-    <!-- Card info -->
-    <input name="number" id="modalPaymentNumbber" type="text" value="4242424242424242">
-    <input  name="exp_month" id="modalPaymentDate" type="text" value="11">
-    <input  name="exp_year" id="modalPaymentDate" type="text" value="2023">
-    <input  name="cvc" id="modalPaymentDate" type="text" value="123">
-
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-
-    <input type="submit" />
-  </form>
+  <input type="submit" />
+</form>
 </div>
 
 </body>


### PR DESCRIPTION
# Describe the scope of the PR

Create payment method on frontend instead of BE.
I moved the payment method creation on the web page. Now it is done by the client and only the result returned by stripe is sent to the server, so we never get to see credit cards numbers.

## Tests

- [x] I manually tested
- [x] I added unit test
- [ ] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
