### PR TITLE
#87 custom user attributes

### DIFF
--- a/src/webapp/src/accounts/entities/user.entity.ts
+++ b/src/webapp/src/accounts/entities/user.entity.ts
@@ -11,6 +11,10 @@ import { BooleanLiteral } from 'typescript'
 
 import { password } from '../../utilities/random'
 
+class UserProfile { //eslint-disable-line
+  [key: string]: any
+}
+
 class UserJson {
   isActive: BooleanLiteral
   resetPasswordToken: string
@@ -22,7 +26,7 @@ class UserJson {
   name: string
   email: string
 
-  [key: string]: any
+  profile: UserProfile
 };
 
 @Entity('users')
@@ -68,6 +72,7 @@ export class UserEntity {
       console.error('User Entity - constructor - error while setting confirmation token', err)
     })
     this.resetPasswordToken = ''
+    this.data.profile = {}
   }
 
   /**

--- a/src/webapp/src/accounts/services/accounts.service.ts
+++ b/src/webapp/src/accounts/services/accounts.service.ts
@@ -86,11 +86,15 @@ export class AccountsService extends BaseService<AccountEntity> {
     }
 
     // Add free tier plan
-    const plans = await this.plansService.getPlans()
-    await this.paymentsService.createFreeSubscription(
-      plans[0],
-      (this.paymentIntegration === 'killbill' ? account.data.killbill.accountId : account.data.stripe.id)
-    )
+    try {
+      const plans = await this.plansService.getPlans()
+      await this.paymentsService.createFreeSubscription(
+        plans[0],
+        (this.paymentIntegration === 'killbill' ? account.data.killbill.accountId : account.data.stripe.id)
+      )
+    } catch (err) {
+      console.error('accountsService - cannot create free subscription')
+    }
 
     try {
       const res = await this.createOne(account)

--- a/src/webapp/src/accounts/test/testData.ts
+++ b/src/webapp/src/accounts/test/testData.ts
@@ -76,7 +76,3 @@ export const mockUserCredentialsService = {
   findUserCredentials: jest.fn((email) => email === mockedUserCredentials.credential ? mockedUserCredentials : undefined),
   isRegistered: jest.fn((userCredentials, password) => userCredentials.credential === mockedUserCredentials.credential && password === 'password' ? mockedUserCredentials : undefined)
 }
-
-export const settingsServiceMock = {
-
-}

--- a/src/webapp/src/accounts/test/testData.ts
+++ b/src/webapp/src/accounts/test/testData.ts
@@ -20,9 +20,22 @@ mockedUserExpiredToken.resetPasswordToken = 'anotherAnother@'
 mockedUserExpiredToken.data.resetPasswordTokenExp = new Date().getTime() - 10 * 1000 * 60
 mockedUserExpiredToken.data.resetPasswordToken = 'anotherAnother@'
 
+export const mockedUserWithLargeProfile: UserEntity = new UserEntity()
+mockedUserWithLargeProfile.id = 3
+mockedUserWithLargeProfile.email = 'user@gmail.com'
+mockedUserWithLargeProfile.password = 'password'
+mockedUserWithLargeProfile.emailConfirmationToken = 'okToken'
+mockedUserWithLargeProfile.data.profile = { foo: 'foo', email: 'internal@email' }
+
 export const mockedRepo = {
   find: jest.fn(_ => []),
-  findById: jest.fn((id) => id === mockedUser.id ? mockedUser : undefined),
+  findById: jest.fn((id) => {
+    switch (id) {
+      case mockedUser.id: return mockedUser
+      case mockedUserWithLargeProfile.id: return mockedUserWithLargeProfile
+      default: return undefined
+    }
+  }),
   createOne: jest.fn((user: UserEntity) => user),
   findByEmail: jest.fn((email) => email === mockedUser.email ? mockedUser : undefined),
   updateOne: jest.fn((id, user: UserEntity) => Object.assign(new UserEntity(), user)),

--- a/src/webapp/src/auth/auth.service.spec.ts
+++ b/src/webapp/src/auth/auth.service.spec.ts
@@ -99,7 +99,7 @@ describe('AuthService', () => {
       it('Must add user data', async () => {
         // console.log('us', service['settingsService'].getUserSettings())
         const validUser = {
-          user: { id: 1, email: 'main@email', data: { email: 'inside@email' } },
+          user: { id: 1, email: 'main@email', data: { profile: { email: 'inside@email' } } },
           credential: {},
           account: { id: 101, data: { name: 'account name' } }
         }

--- a/src/webapp/src/auth/auth.service.ts
+++ b/src/webapp/src/auth/auth.service.ts
@@ -56,6 +56,11 @@ export class AuthService {
   }
 
   async getTokenPayloadFromUserModel (validUser: ValidUser): Promise<RequestUser | null> {
+    const { allowedKeys } = await this.settingsService.getUserSettings()
+    const userData = allowedKeys.reduce((acc, key: string) => {
+      acc[`user_${key}`] = validUser.user.data[key] ?? '' // using user_${key} to flatten the jwt data
+      return acc
+    }, {})
     return {
       nonce: '', // TODO
       id: validUser.user.id,
@@ -64,7 +69,8 @@ export class AuthService {
       status: 'active', // TODO: use actual value
       email: validUser.user.email,
       email_verified: validUser.user?.data.emailConfirmed ?? false,
-      staff: validUser.user?.isAdmin ?? false
+      staff: validUser.user?.isAdmin ?? false,
+      ...userData
     }
   }
 

--- a/src/webapp/src/auth/jwt.strategy.ts
+++ b/src/webapp/src/auth/jwt.strategy.ts
@@ -37,10 +37,23 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     const contextId = ContextIdFactory.getByRequest(request)
     const authService = await this.moduleRef.resolve(AuthService, contextId)
 
-    // Validate subscriptions here
+    const validUser = await authService.getUserInfo(payload.email)
+
+    if (validUser == null) {
+      console.log('jwtStrategy - cannot get a valid user')
+      return null
+    }
+
+    // update jwt here
     // if payload is not up to date wrt models, issue a new jwt
     // this happens if anything changes after login, like a plan change
-    const requestUserWithSubscription = await authService.updateActiveSubscription(payload)
+    const requestUser = await authService.getTokenPayloadFromUserModel(validUser)
+    if (requestUser == null) {
+      console.error('localStrategy - validate - error while creating token')
+      return null
+    }
+
+    const requestUserWithSubscription = await authService.updateActiveSubscription(requestUser)
     if (requestUserWithSubscription == null) {
       console.error('jwtStrategy - validate - error while add subscription to token')
       return null

--- a/src/webapp/src/interceptors/jwt.interceptor.ts
+++ b/src/webapp/src/interceptors/jwt.interceptor.ts
@@ -1,0 +1,19 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common'
+import { Observable } from 'rxjs'
+import { AuthService } from 'src/auth/auth.service'
+
+@Injectable()
+export class JwtInterceptor implements NestInterceptor {
+  constructor (
+    private readonly authService: AuthService
+  ) { }
+
+  async intercept (context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const ctx = context.switchToHttp()
+    const response = ctx.getResponse()
+    const request: any = ctx.getRequest<Request>()
+    request.user != null && await this.authService.setJwtCookie(request, response, request.user)
+
+    return next.handle()
+  }
+}

--- a/src/webapp/src/website/controllers/user.controller.ts
+++ b/src/webapp/src/website/controllers/user.controller.ts
@@ -11,6 +11,7 @@ import { Response } from 'express'
 
 import { UserRequiredAuthGuard } from '../../auth/auth.guard'
 import { AccountsService } from '../../accounts/services/accounts.service'
+import { UsersService } from '../../accounts/services/users.service'
 import { PlansService } from '../../payments/services/plans.service'
 import { SettingsService } from '../../settings/settings.service'
 
@@ -20,8 +21,9 @@ import { renderUserPage } from '../utilities/render'
 export class UserController {
   constructor (
     private readonly accountsService: AccountsService,
-    private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
     private readonly plansService: PlansService,
+    private readonly configService: ConfigService,
     private readonly settingsService: SettingsService
   ) {}
 
@@ -52,6 +54,18 @@ export class UserController {
     return renderUserPage(req, res, 'team', {
       account_users
     })
+  }
+
+  @UseGuards(UserRequiredAuthGuard)
+  @Post('/profile')
+  async updateUserProfile (@Request() req, @Res() res: Response): Promise<any> {
+    const updatedUser = await this.usersService.updateUserProfile(req.body, req.user.id)
+
+    if (updatedUser == null) {
+      return res.redirect('/error')
+    }
+
+    return res.redirect('/user/team')
   }
 
   @UseGuards(UserRequiredAuthGuard)

--- a/src/webapp/src/website/website.module.ts
+++ b/src/webapp/src/website/website.module.ts
@@ -1,4 +1,5 @@
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common'
+import { Module, NestModule, MiddlewareConsumer, Scope } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
 
 import { AccountsModule } from '../accounts/accounts.module'
 import { AuthModule } from '../auth/auth.module'
@@ -10,14 +11,23 @@ import { UserController } from './controllers/user.controller'
 import { PublicController } from './controllers/public.controller'
 import { WebsiteDataMiddleware } from 'src/middlewares/websiteData.middleware'
 
+import { JwtInterceptor } from '../interceptors/jwt.interceptor'
+
 @Module({
-  imports: [SettingsModule, AuthModule, AccountsModule],
+  imports: [AuthModule, SettingsModule, AccountsModule],
   controllers: [
     CommonController,
     AuthenticationController,
     PaymentsController,
     UserController,
     PublicController
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: JwtInterceptor,
+      scope: Scope.TRANSIENT
+    }
   ]
 })
 export class WebsiteModule implements NestModule {

--- a/src/webapp/test/authentication.e2e-spec.ts
+++ b/src/webapp/test/authentication.e2e-spec.ts
@@ -33,7 +33,7 @@ import jwt_decode from 'jwt-decode'
  */
 const DB_INIT: string = `
 INSERT INTO settings VALUES (1,'website','{"name": "Uplom", "domain_primary": "uplom.com"}', NOW(), NOW());
-INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (101,'admin@uplom.com','password',1,1,1,1,'{}'),(102,'user@gmail.com','password',0,1,1,'1k-X4PTtCQ7lGQ','{"resetPasswordToken": "1k-X4PTtCQ7lGQ", "resetPasswordTokenExp": "1708940883080"}'),(111,'nosub@gmail.com','password',0,1,1,1,'{}');
+INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (101,'admin@uplom.com','password',1,1,1,1,'{"profile":{}}'),(102,'user@gmail.com','password',0,1,1,'1k-X4PTtCQ7lGQ','{"resetPasswordToken": "1k-X4PTtCQ7lGQ", "resetPasswordTokenExp": "1708940883080", "profile": {}}'),(111,'nosub@gmail.com','password',0,1,1,1,'{}');
 INSERT INTO accounts (id, owner_id, data) VALUES (201, 101, '{}'),(211, 111, '{}');
 INSERT INTO accounts_users (account_id, user_id) VALUES (201, 101),(201, 102),(211, 111);
 INSERT INTO users_credentials (credential, userId, json) VALUES ('admin@uplom.com',101,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}'),('user@gmail.com',102,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}'),('nosub@gmail.com',111,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}');

--- a/src/webapp/themes/bare/user.liquid
+++ b/src/webapp/themes/bare/user.liquid
@@ -4,6 +4,20 @@
 
 <h1>User profile</h1>
 
+<form action="/user/profile" method="POST">
+  <div>
+      <input type="text" name="username" value="{{user.user_username}}" required>
+  </div>
+  <div>
+    <input type="text" name="region" value="{{user.user_region}}" required>
+  </div>
+
+  <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+  <input type="submit" />
+</form>
+
+
+
 {{ alert.text }}
 
 <h2>Team</h2>
@@ -22,13 +36,11 @@
       {{error.email}}
   </div>
   <div>
-      <input type="text" id="name" name="name" value="John" required>
-      {{error.name}}
+    <input type="text" name="username" value="John" required>
   </div>
   <div>
-    <input type="text" id="extra" name="extra" value="extra" required>
-    {{error.name}}
-</div>
+    <input type="text" name="region" value="EU" required>
+  </div>
 
   <input type="hidden" name="_csrf" value="{{ csrf_token }}">
   <input type="submit" />


### PR DESCRIPTION
# Describe the scope of the PR

Add support for custom user attributes.
To to do this properly I moved the profile data into a specific key in the `user.data` object so that they don't mess up with the rest of the data.

Only fields that are listed in the userSettings under the `allowedKeys` property are accepted.

To keep the data fresh I have added a logic to refresh the user data and the JWT at every request. Data is refreshed in the `JwtStrategy`, while for the JWT I have created a `JwtInterceptor` that is used by the Website module. Note that it was necessary to change the Injection  scope of the interceptor to `TRANSIENT` (see https://docs.nestjs.com/fundamentals/injection-scopes)

_Solved_

#87

_Added_

#88 

## Add any shortcut taken

None

## Tests

- [x] I manually tested
- [x] I added unit test
- [ ] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
