### PR TITLE
feat: delete user

### DIFF
--- a/data/themes/bare/user.liquid
+++ b/data/themes/bare/user.liquid
@@ -44,11 +44,23 @@
 
 <ul>
 {% for user in account_users %}
-  <li>{{ user.name }}, {{ user.email }}</li>
+  <li>{{ user.name }}, {{ user.email }} <button onclick="
+  fetch('/api/v1/user/{{user.id}}', {
+    method: 'DELETE', // *GET, POST, PUT, DELETE, etc.
+    mode: 'cors', // no-cors, *cors, same-origin
+    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+    credentials: 'same-origin', // include, *same-origin, omit
+    headers: {
+      'Content-Type': 'application/json'
+      // 'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    redirect: 'follow', // manual, *follow, error
+    referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+  });window.location.reload(false)">delete</button></li>
 {% endfor %}
 </ul>
 
-<h3>Add user to the teaam</h3>
+<h3>Add user to the team</h3>
 
 <form action="/user/team" method="POST">
   <div>

--- a/src/webapp/src/accounts/services/accounts.service.ts
+++ b/src/webapp/src/accounts/services/accounts.service.ts
@@ -140,7 +140,7 @@ export class AccountsService extends BaseService<AccountEntity> {
       return []
     }
 
-    return users
+    return users.filter(u => u != null)
   }
 
   async setOwner (account: AccountEntity, userId: number): Promise<any> {
@@ -220,6 +220,11 @@ export class AccountsService extends BaseService<AccountEntity> {
     const account = await this.findById(users[0]?.account_id)
 
     return account
+  }
+
+  async deleteUser (userId: number): Promise<Boolean> {
+    // TODO: implement this
+    return true
   }
 
   /**

--- a/src/webapp/src/accounts/services/accountsUsers.service.spec.ts
+++ b/src/webapp/src/accounts/services/accountsUsers.service.spec.ts
@@ -12,7 +12,7 @@ import { AccountsService } from './accounts.service'
 import { AccountEntity } from '../entities/account.entity'
 import { UserCredentialsService } from './userCredentials.service'
 import { UserCredentialsEntity } from '../entities/userCredentials.entity'
-import { mockUserCredentialsEntity } from '../test/testData'
+import { mockAccountsUsersRepo, mockUserCredentialsEntity } from '../test/testData'
 import { NotificationsService } from '../../notifications/notifications.service'
 import { SettingsService } from '../../settings/settings.service'
 import { PaymentsService } from '../../payments/services/payments.service'
@@ -46,7 +46,7 @@ describe('AccountsUsers Service', () => {
         AccountsUsersService,
         {
           provide: getRepositoryToken(AccountUserEntity),
-          useValue: mockedRepo
+          useValue: mockAccountsUsersRepo
         },
         UserCredentialsService,
         {
@@ -88,7 +88,7 @@ describe('AccountsUsers Service', () => {
     )
 
     // We must manually set the following because extending TypeOrmQueryService seems to break it
-    Object.keys(mockedRepo).forEach(f => (service[f] = mockedRepo[f]))
+    Object.keys(mockAccountsUsersRepo).forEach(f => (service[f] = mockAccountsUsersRepo[f]))
     service.accountsUsersRepository = repo
   })
 
@@ -99,14 +99,27 @@ describe('AccountsUsers Service', () => {
 
   describe('getAll', () => {
     it('should return an array of AccountsUsers for the account called', async () => {
-      const repoSpy = jest.spyOn(mockedRepo, 'query')
+      const repoSpy = jest.spyOn(mockAccountsUsersRepo, 'query')
       const accountId = 1
       const accountsUsers = await service.getUsers(accountId)
-      expect(accountsUsers).toEqual([])
+      expect(accountsUsers).toEqual([{}])
       expect(repoSpy).toBeCalledTimes(1)
       expect(repoSpy).toBeCalledWith({
         filter: { account_id: { eq: accountId } }
       })
+    })
+  })
+
+  describe('delete accounts-user relationship', () => {
+    it('should delete all of the user credentials', async () => {
+      const repoSpy = jest.spyOn(mockAccountsUsersRepo, 'deleteMany')
+      const userId = 1
+
+      const res = await service.deleteUser(userId)
+
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(repoSpy).toBeCalledWith({ user_id: { eq: userId } })
+      expect(res).toBe(0) // the value 0 is hardcoded in the mock definition
     })
   })
 })

--- a/src/webapp/src/accounts/services/accountsUsers.service.ts
+++ b/src/webapp/src/accounts/services/accountsUsers.service.ts
@@ -60,6 +60,15 @@ export class AccountsUsersService extends BaseService<AccountUserEntity> {
     return accountUser
   }
 
+  async deleteUser (userId: number): Promise<number | null> {
+    try {
+      return (await this.deleteMany({ user_id: { eq: userId } })).deletedCount
+    } catch (error) {
+      console.error('AccountsUsersService - deleteUser - error while deleteMany', userId, error)
+      return null
+    }
+  }
+
   /**
    * Get user by email
    *

--- a/src/webapp/src/accounts/services/userCredentials.service.spec.ts
+++ b/src/webapp/src/accounts/services/userCredentials.service.spec.ts
@@ -111,4 +111,17 @@ describe('UserCredentials', () => {
       expect(expUser).toBeNull()
     })
   })
+
+  describe('delete user credentials', () => {
+    it('should delete all of the user credentials', async () => {
+      const repoSpy = jest.spyOn(mockUserCredentialsEntity, 'deleteMany')
+      const userId = 1
+
+      const res = await service.deleteUserCredentials(userId)
+
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(repoSpy).toBeCalledWith({ userId: { eq: userId } })
+      expect(res).toBe(0) // the value 0 is hardcoded in the mock definition
+    })
+  })
 })

--- a/src/webapp/src/accounts/services/userCredentials.service.ts
+++ b/src/webapp/src/accounts/services/userCredentials.service.ts
@@ -55,6 +55,15 @@ export class UserCredentialsService extends BaseService<UserCredentialsEntity> {
     }
   }
 
+  async deleteUserCredentials (userId: number): Promise<number | null> {
+    try {
+      return (await this.deleteMany({ userId: { eq: userId } })).deletedCount
+    } catch (error) {
+      console.error('UserCredentialsService - deleteUserCredentials - error while deleteMany', userId, error)
+      return null
+    }
+  }
+
   async changePassword (credential: string, password: string): Promise<UserCredentialsEntity | null> {
     if (credential === null || password === null) {
       return null

--- a/src/webapp/src/accounts/services/users.service.spec.ts
+++ b/src/webapp/src/accounts/services/users.service.spec.ts
@@ -7,7 +7,7 @@ import { TypeOrmQueryService } from '@nestjs-query/query-typeorm'
 import { UsersService } from './users.service'
 import { UserEntity } from '../entities/user.entity'
 import { NewUserInput } from '../dto/new-user.input'
-import { mockedCommunicationService, mockedRandom, mockedRepo, mockedUser, mockedUserExpiredToken, mockedUserWithLargeProfile, mockUserCredentialsEntity, mockedSettingRepo } from '../test/testData'
+import { mockedCommunicationService, mockedRandom, mockedRepo, mockedUser, mockedUserExpiredToken, mockUserCredentialsEntity, mockedSettingRepo } from '../test/testData'
 import { UserCredentialsService } from '../services/userCredentials.service'
 import { UserCredentialsEntity } from '../entities/userCredentials.entity'
 import { NotificationsService } from '../../notifications/notifications.service'
@@ -85,131 +85,6 @@ describe('UsersService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined()
     expect(service.accountsRepository).toEqual(repo)
-  })
-
-  describe('user creation', () => {
-    it('should add the email', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
-      const userInput = {
-        email: 'foo@email.com',
-        password: 'password',
-        username: 'username',
-        data: { name: 'foo', email: 'foo@email.com' }
-      }
-
-      await service.addUser(userInput)
-
-      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(addedUser.email).toBe(userInput.email)
-    })
-
-    it('should add the username if passed', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
-      const userInput = {
-        email: 'foo@email.com',
-        password: 'password',
-        data: { username: 'username', name: 'foo', email: 'foo@email.com' }
-      }
-
-      await service.addUser(userInput)
-
-      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(addedUser.username).toBe(userInput.data.username)
-    })
-
-    it('should not add the username if not passed', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
-      const userInput = {
-        email: 'foo@email.com',
-        password: 'password',
-        data: { name: 'foo', email: 'foo@email.com' }
-      }
-
-      await service.addUser(userInput)
-
-      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(addedUser.username).toBeUndefined()
-    })
-
-    it('should set additional data', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
-      const userInput = {
-        email: 'foo@email.com',
-        password: 'password',
-        data: { name: 'foo', email: 'foo@email.com' }
-      }
-
-      await service.addUser(userInput)
-
-      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(addedUser.data.profile.email).toBe(userInput.email)
-      expect(addedUser.data.profile.name).toBeUndefined()
-      expect(addedUser.data.profile.unused).toBeUndefined()
-    })
-
-    it('should add user credentials', async () => {
-      const repoSpy = jest.spyOn(mockedUserCredentialsService, 'addUserCredentials')
-      const userInput = {
-        email: 'foo@email.com',
-        password: 'password',
-        data: { name: 'foo', email: 'foo@email.com' }
-      }
-
-      await service.addUser(userInput)
-
-      const userCredential: any = repoSpy.mock.calls[0][0]
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(userCredential?.credential).toBe(userInput.email)
-      expect(userCredential.json.encryptedPassword).not.toBeUndefined()
-      expect(userCredential.json.encryptedPassword).not.toBe(userInput.password)
-    })
-  })
-
-  describe('user update', () => {
-    it('should update the user data', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
-      const userUpdate = {
-        name: 'foo',
-        email: 'foo@email.com'
-      }
-
-      await service.updateUserProfile(userUpdate, mockedUser.id)
-
-      const expectedData = {
-        data: {
-          ...mockedUser.data,
-          profile: {
-            email: 'foo@email.com',
-            unused: ''
-          }
-        }
-      }
-
-      expect(repoSpy).toBeCalledTimes(1)
-      expect(repoSpy).toBeCalledWith(1, expectedData)
-    })
-
-    it('should keep the user data when not present in the updated data', async () => {
-      // the allowed keys are 'email' and 'unused'
-      const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
-      const userUpdate = {
-        name: 'foo'
-      }
-
-      await service.updateUserProfile(userUpdate, mockedUserWithLargeProfile.id)
-
-      const updatedUser: UserEntity = repoSpy.mock.calls[0][1]
-      expect(updatedUser.data.profile.email).toBe(mockedUserWithLargeProfile.data.profile.email)
-    })
   })
 
   describe('Email confirmation', () => {

--- a/src/webapp/src/accounts/services/users.service.ts
+++ b/src/webapp/src/accounts/services/users.service.ts
@@ -159,6 +159,33 @@ export class UsersService extends BaseService<UserEntity> {
     }
   }
 
+  async deleteUser (userId: number): Promise<Boolean> {
+    const user = this.findById(userId)
+    if (user == null) {
+      console.error('usersService - deleteUser - user not found', userId)
+      return false
+    }
+
+    if (await this.userCredentialsService.deleteUserCredentials(userId) == null) {
+      console.error('usersService - deleteUser - error while removing user credentials', userId)
+      return false
+    }
+
+    try {
+      const deletedUser = await this.deleteOne(userId)
+
+      if (deletedUser == null) {
+        console.error('usersService - deleteUser - error while removing user', userId)
+        return false
+      }
+
+      return true
+    } catch (error) {
+      console.error('usersService - deleteUser - exception  while removing user', userId, error)
+      return false
+    }
+  }
+
   async confirmEmail (token: string): Promise<UserEntity | null> {
     if (token === '') {
       console.error('confirmEmail - error in parameters')

--- a/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
+++ b/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
@@ -1,0 +1,234 @@
+// import { REQUEST } from '@nestjs/core'
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { TypeOrmQueryService } from '@nestjs-query/query-typeorm'
+
+import { UsersService } from './users.service'
+import { UserEntity } from '../entities/user.entity'
+import { mockedCommunicationService, mockedRandom, mockedRepo, mockedUser, mockedUserWithLargeProfile, mockUserCredentialsEntity, mockedSettingRepo } from '../test/testData'
+import { UserCredentialsService } from './userCredentials.service'
+import { UserCredentialsEntity } from '../entities/userCredentials.entity'
+import { NotificationsService } from '../../notifications/notifications.service'
+import { SettingsService } from '../../settings/settings.service'
+import { PaymentsService } from '../../payments/services/payments.service'
+import { PlansService } from '../../payments/services/plans.service'
+import { ValidationService } from '../../validator/validation.service'
+
+const mockedUserCredentialsService = {
+  ...mockUserCredentialsEntity,
+  changePassword: jest.fn(),
+  addUserCredentials: jest.fn(),
+  deleteUserCredentials: jest.fn().mockReturnValue(true)
+}
+
+describe('UsersService Lifecycle', () => {
+  let service // Removed type AccountsService because we must overwrite the accountsRepository property
+  let repo: Repository<UserEntity>
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(UserEntity),
+          useValue: mockedRepo
+        },
+        UserCredentialsService,
+        {
+          provide: getRepositoryToken(UserCredentialsEntity),
+          useValue: mockedUserCredentialsService
+        },
+        {
+          provide: NotificationsService,
+          useValue: { sendEmail: jest.fn((to, template, data) => true) }
+        },
+        {
+          provide: SettingsService,
+          useValue: mockedSettingRepo
+        },
+        {
+          provide: PaymentsService,
+          useValue: {}
+        },
+        {
+          provide: PlansService,
+          useValue: {}
+        },
+        {
+          provide: ValidationService,
+          useValue: {}
+        },
+        // We must also pass TypeOrmQueryService
+        TypeOrmQueryService
+      ]
+    }).compile()
+
+    service = await module.get(UsersService)
+    repo = await module.get<Repository<UserEntity>>(
+      getRepositoryToken(UserEntity)
+    )
+
+    // We must manually set the following because extending TypeOrmQueryService seems to break it
+    Object.keys(mockedRepo).forEach(f => (service[f] = mockedRepo[f]))
+    service.accountsRepository = repo
+    service.userCredentialsService = mockedUserCredentialsService
+    service.communicationService = mockedCommunicationService
+    service.settingsService = mockedSettingRepo
+    service.random = { ...mockedRandom }
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+    expect(service.accountsRepository).toEqual(repo)
+  })
+
+  describe('user creation', () => {
+    it('should add the email', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        username: 'username',
+        data: { name: 'foo', email: 'foo@email.com' }
+      }
+
+      await service.addUser(userInput)
+
+      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(addedUser.email).toBe(userInput.email)
+    })
+
+    it('should add the username if passed', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { username: 'username', name: 'foo', email: 'foo@email.com' }
+      }
+
+      await service.addUser(userInput)
+
+      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(addedUser.username).toBe(userInput.data.username)
+    })
+
+    it('should not add the username if not passed', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { name: 'foo', email: 'foo@email.com' }
+      }
+
+      await service.addUser(userInput)
+
+      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(addedUser.username).toBeUndefined()
+    })
+
+    it('should set additional data', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { name: 'foo', email: 'foo@email.com' }
+      }
+
+      await service.addUser(userInput)
+
+      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(addedUser.data.profile.email).toBe(userInput.email)
+      expect(addedUser.data.profile.name).toBeUndefined()
+      expect(addedUser.data.profile.unused).toBeUndefined()
+    })
+
+    it('should add user credentials', async () => {
+      const repoSpy = jest.spyOn(mockedUserCredentialsService, 'addUserCredentials')
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { name: 'foo', email: 'foo@email.com' }
+      }
+
+      await service.addUser(userInput)
+
+      const userCredential: any = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(userCredential?.credential).toBe(userInput.email)
+      expect(userCredential.json.encryptedPassword).not.toBeUndefined()
+      expect(userCredential.json.encryptedPassword).not.toBe(userInput.password)
+    })
+  })
+
+  describe('user update', () => {
+    it('should update the user data', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
+      const userUpdate = {
+        name: 'foo',
+        email: 'foo@email.com'
+      }
+
+      await service.updateUserProfile(userUpdate, mockedUser.id)
+
+      const expectedData = {
+        data: {
+          ...mockedUser.data,
+          profile: {
+            email: 'foo@email.com',
+            unused: ''
+          }
+        }
+      }
+
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(repoSpy).toBeCalledWith(1, expectedData)
+    })
+
+    it('should keep the user data when not present in the updated data', async () => {
+      // the allowed keys are 'email' and 'unused'
+      const repoSpy = jest.spyOn(mockedRepo, 'updateOne')
+      const userUpdate = {
+        name: 'foo'
+      }
+
+      await service.updateUserProfile(userUpdate, mockedUserWithLargeProfile.id)
+
+      const updatedUser: UserEntity = repoSpy.mock.calls[0][1]
+      expect(updatedUser.data.profile.email).toBe(mockedUserWithLargeProfile.data.profile.email)
+    })
+  })
+
+  describe('delete user', () => {
+    it('should dete the user', async () => {
+      const repoSpy = jest.spyOn(mockedRepo, 'deleteOne')
+
+      const res = await service.deleteUser(1)
+
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(repoSpy).toBeCalledWith(1)
+      expect(res).toBeTruthy()
+    })
+
+    it('should delete all of the userCredentials', async () => {
+      const repoSpy = jest.spyOn(mockedUserCredentialsService, 'deleteUserCredentials')
+
+      const res = await service.deleteUser(1)
+
+      expect(repoSpy).toBeCalledTimes(1)
+      expect(repoSpy).toBeCalledWith(1)
+      expect(res).toBeTruthy()
+    })
+  })
+})

--- a/src/webapp/src/accounts/test/testData.ts
+++ b/src/webapp/src/accounts/test/testData.ts
@@ -1,6 +1,27 @@
 import { UserEntity } from '../entities/user.entity'
 import { UserCredentialsEntity } from '../entities/userCredentials.entity'
 
+const mockGenericRepo = {
+  find: jest.fn(id => id !== 999 ? {} : undefined),
+  findOne: jest.fn().mockReturnValue([{}]),
+  query: jest.fn().mockReturnValue([{}]),
+  createOne: jest.fn(entity => entity),
+  updateOne: jest.fn((id, update) => ({ id, ...update })),
+  deleteOne: jest.fn(id => ({})),
+  deleteMany: jest.fn().mockReturnValue({ deletedCount: 0 })
+}
+
+export const mockAccountsUsersRepo = {
+  ...mockGenericRepo,
+  createOne: jest.fn(accountUser => accountUser)
+}
+
+// TODO: refactor below this point
+
+export const mockedCommunicationService = {
+  sendEmail: jest.fn(_ => [])
+}
+
 export const mockedUser: UserEntity = new UserEntity()
 mockedUser.id = 1
 mockedUser.email = 'user@gmail.com'
@@ -39,6 +60,7 @@ export const mockedRepo = {
   createOne: jest.fn((user: UserEntity) => user),
   findByEmail: jest.fn((email) => email === mockedUser.email ? mockedUser : undefined),
   updateOne: jest.fn((id, user: UserEntity) => Object.assign(new UserEntity(), user)),
+  deleteOne: jest.fn(id => ({})),
   query: jest.fn(query => {
     const res = [mockedUser, mockedUserExpiredToken].filter(u => {
       if (u.emailConfirmationToken === query?.filter?.emailConfirmationToken?.eq) {
@@ -60,15 +82,13 @@ export const mockUserCredentialsEntity = {
   findOne: jest.fn(({ where: { credential } }) => credential === mockedUserCredentials.credential ? mockedUserCredentials : undefined),
   createOne: jest.fn((userCredential) => userCredential),
   updateOne: jest.fn((id) => id === mockedUserCredentials.id ? mockedUserCredentials : undefined),
+  deleteMany: jest.fn(filter => ({ deletedCount: 0 })),
   query: jest.fn(query => {
     const res = [mockedUserCredentials].filter(u => u.credential === query?.filter?.credential?.eq ?? undefined)
     return res
   })
 }
 
-export const mockedCommunicationService = {
-  sendEmail: jest.fn(_ => [])
-}
 export const mockedSettingRepo = {
   getWebsiteRenderingVariables: jest.fn(_ => []),
   getUserSettings: jest.fn(_ => ({ allowedKeys: ['email', 'unused'] })),

--- a/src/webapp/src/api/controllers/v1/api.user.controller.ts
+++ b/src/webapp/src/api/controllers/v1/api.user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, UseGuards, Request, Res } from '@nestjs/common'
+import { Controller, Post, Delete, UseGuards, Request, Res, Param } from '@nestjs/common'
 import { Response } from 'express'
 import { SettingsService } from '../../../settings/settings.service'
 import { AccountsService } from '../../../accounts/services/accounts.service'
@@ -55,6 +55,38 @@ export class ApiV1UserController {
     return res.json({
       statusCode: 200,
       message: 'Password changed'
+    })
+  }
+
+  @UseGuards(UserRequiredAuthGuard)
+  @Delete(':userId')
+  async handleDeleteUser (@Request() req, @Res() res: Response, @Param('userId') userId): Promise<any> {
+    if (userId == null) {
+      return res.json({
+        statusCode: 400,
+        error: 'userId not valid'
+      })
+    }
+
+    try {
+      const wasDeleted = await this.usersService.deleteUser(userId)
+      if (wasDeleted !== true) {
+        return res.json({
+          statusCode: 500,
+          message: `Error while removing user ${userId as string}`
+        })
+      }
+    } catch (error) {
+      console.error('ApiV1UserController - handleDeleteUser', error)
+      return res.json({
+        statusCode: 500,
+        message: `err ${error.message as string}`
+      })
+    }
+
+    return res.json({
+      statusCode: 200,
+      error: `User ${userId as string} removed`
     })
   }
 }

--- a/src/webapp/test/change-password.e2e-spec.ts
+++ b/src/webapp/test/change-password.e2e-spec.ts
@@ -14,11 +14,10 @@ import { DB_CONFIG } from './config'
 import { configureApp } from '../src/main.app'
 import { AppService } from '../src/app.service'
 import { AuthModule } from '../src/auth/auth.module'
-import { ValidatorModule } from '../src/validator/validator.module'
+import { AccountsModule } from '../src/accounts/accounts.module'
+import { ApiV1UserController } from '../src/api/controllers/v1/api.user.controller'
 import { ApiV1AutheticationController } from '../src/api/controllers/v1/api.authentication.controller'
 import { StripeService } from '../src/payments/services/stripe.service'
-
-import jwt_decode from 'jwt-decode'
 
 // const keys = {
 //   jwt_private_key: '-----BEGIN PRIVATE KEY-----nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQgxjRaB1myLLnts/gMj3sPnwwlnF9BxLF86108qAH4g5zqhRANCAAQfUj/9Q1zJBqw+HX0e37+fHo9BoU4sE6MbnE4yKeEua8pncGu53WWZ6ExJ2Ohnf5gPYRoj3f1z3utCDjADPuFSOn-----END PRIVATE KEY-----n',
@@ -26,12 +25,11 @@ import jwt_decode from 'jwt-decode'
 // }
 
 /**
- * User: 101, 102, 111
+ * User: 101, 102, 103
  * Account: 201 => users 101, 102
  *          211 => user 111
  * Plans: 401, 402, 403
- * Payments: 501 => account 201
- *           511 => account 211 INVALID
+ * Payments: 501 => user 101
  */
 const DB_INIT: string = `
 TRUNCATE accounts;
@@ -43,31 +41,20 @@ TRUNCATE payments;
 TRUNCATE settings;
 
 INSERT INTO settings VALUES (1,'website','{"name": "Uplom", "domain_primary": "uplom.com"}', NOW(), NOW());
-INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (101,'admin@uplom.com','password',1,1,1,1,'{"profile":{}}');
-INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (102,'user@gmail.com','password',0,1,1,'1k-X4PTtCQ7lGQ','{"resetPasswordToken": "1k-X4PTtCQ7lGQ", "resetPasswordTokenExp": "1708940883080", "profile": {}}');
-INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (111,'nosub@gmail.com','password',0,1,1,1,'{}');
-INSERT INTO accounts (id, owner_id, data) VALUES (201, 101, '{}');
-INSERT INTO accounts (id, owner_id, data) VALUES (211, 111, '{}');
-INSERT INTO accounts_users (account_id, user_id) VALUES (201, 101);
-INSERT INTO accounts_users (account_id, user_id) VALUES (201, 102);
-INSERT INTO accounts_users (account_id, user_id) VALUES (211, 111);
-INSERT INTO users_credentials (credential, userId, json) VALUES ('admin@uplom.com',101,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}');
-INSERT INTO users_credentials (credential, userId, json) VALUES ('user@gmail.com',102,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}');
-INSERT INTO users_credentials (credential, userId, json) VALUES ('nosub@gmail.com',111,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}');
+INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (101,'admin@uplom.com','password',1,1,1,1,'{"profile":{}}'),(102,'user@gmail.com','password',0,1,1,'1k-X4PTtCQ7lGQ','{"resetPasswordToken": "1k-X4PTtCQ7lGQ", "resetPasswordTokenExp": "1708940883080", "profile": {}}'),(111,'nosub@gmail.com','password',0,1,1,1,'{}');
+INSERT INTO accounts (id, owner_id, data) VALUES (201, 101, '{}'),(211, 111, '{}');
+INSERT INTO accounts_users (account_id, user_id) VALUES (201, 101),(201, 102),(211, 111);
+INSERT INTO users_credentials (credential, userId, json) VALUES ('admin@uplom.com',101,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}'),('user@gmail.com',102,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}'),('nosub@gmail.com',111,'{"encryptedPassword": "$2b$12$lQHyC/s1tdH1kTwrayYyUOISPteINC5zbHL2eWL6On7fMtIgwYdNm"}');
 INSERT INTO plans (id,created,updated,product,prices,plan) VALUES (401,NOW(),NOW(),'{"id":"prod_J0MI7GCNSSh3eQ","object":"product","active":true,"attributes":[],"created":1614166256,"description":"Starter plan","images":[],"livemode":false,"metadata":{},"name":"Starter","statement_descriptor":null,"type":"service","unit_label":null,"updated":1614166256}','[{"id":"price_1IOLa0H8nkbB9IbKGSbOahRx","object":"price","active":true,"billing_scheme":"per_unit","created":1614166256,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MI7GCNSSh3eQ","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":3500,"unit_amount_decimal":"3500"},{"id":"price_1IOLa1H8nkbB9IbKR5c7gSfx","object":"price","active":true,"billing_scheme":"per_unit","created":1614166257,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MI7GCNSSh3eQ","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":34800,"unit_amount_decimal":"34800"}]','{"id":"prod_J0MI7GCNSSh3eQ","description":"Starter plan","name":"Starter","features":[{"name":"3 sites"},{"name":"1,000 shares"},{"name":"Email support"}],"button":"Choose","prices":{"month":{"id":"price_1IOLa0H8nkbB9IbKGSbOahRx","unit_amount_decimal":"3500","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MI7GCNSSh3eQ","currency":"usd","unit_amount_hr":35},"year":{"id":"price_1IOLa1H8nkbB9IbKR5c7gSfx","unit_amount_decimal":"34800","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MI7GCNSSh3eQ","currency":"usd","unit_amount_hr":348}}}');
 INSERT INTO plans (id,created,updated,product,prices,plan) VALUES (402,NOW(),NOW(),'{"id":"prod_J0MIPuMEZ7pG2O","object":"product","active":true,"attributes":[],"created":1614166257,"description":"Pro plan","images":[],"livemode":false,"metadata":{},"name":"Pro","statement_descriptor":null,"type":"service","unit_label":null,"updated":1614166257}','[{"id":"price_1IOLa1H8nkbB9IbKVCb5iqAE","object":"price","active":true,"billing_scheme":"per_unit","created":1614166257,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":11900,"unit_amount_decimal":"11900"},{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"price","active":true,"billing_scheme":"per_unit","created":1614166258,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":118800,"unit_amount_decimal":"118800"}]','{"id":"prod_J0MIPuMEZ7pG2O","description":"Pro plan","name":"Pro","features":[{"name":"100 sites"},{"name":"Unlimited shares"},{"name":"Premium support"}],"button":"Choose","primary":true,"prices":{"month":{"id":"price_1IOLa1H8nkbB9IbKVCb5iqAE","unit_amount_decimal":"11900","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MIPuMEZ7pG2O","currency":"usd","unit_amount_hr":119},"year":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","unit_amount_decimal":"118800","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MIPuMEZ7pG2O","currency":"usd","unit_amount_hr":1188}}}');
 INSERT INTO plans (id,created,updated,product,prices,plan) VALUES (403,NOW(),NOW(),'{"id":"prod_J0MIdVcEMSWbe4","object":"product","active":true,"attributes":[],"created":1614166258,"description":"Enterprise plan","images":[],"livemode":false,"metadata":{},"name":"Enterprise","statement_descriptor":null,"type":"service","unit_label":null,"updated":1614166258}','[{"id":"price_1IOLa2H8nkbB9IbKst64IUqB","object":"price","active":true,"billing_scheme":"per_unit","created":1614166258,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIdVcEMSWbe4","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":0,"unit_amount_decimal":"0"},{"id":"price_1IOLa3H8nkbB9IbKYtfLXSMf","object":"price","active":true,"billing_scheme":"per_unit","created":1614166259,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIdVcEMSWbe4","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":0,"unit_amount_decimal":"0"}]','{"id":"prod_J0MIdVcEMSWbe4","description":"Enterprise plan","name":"Enterprise","features":[{"name":"All features"},{"name":"Cloud or on-prem"},{"name":"Premium support"}],"button":"Contact us","priceText":"Let talk","prices":{"month":{"id":"price_1IOLa2H8nkbB9IbKst64IUqB","unit_amount_decimal":"0","recurring":{"aggregate_usage":null,"interval":"month","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MIdVcEMSWbe4","currency":"usd","unit_amount_hr":0},"year":{"id":"price_1IOLa3H8nkbB9IbKYtfLXSMf","unit_amount_decimal":"0","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"product":"prod_J0MIdVcEMSWbe4","currency":"usd","unit_amount_hr":0}}}');
 INSERT INTO payments (id,account_id,status,data) VALUES (501,201,'trialing','{"id":"sub_J39ScO2qo7sBUN","object":"subscription","application_fee_percent":null,"billing_cycle_anchor":1614810419,"billing_thresholds":null,"cancel_at":null,"cancel_at_period_end":false,"canceled_at":null,"collection_method":"charge_automatically","created":1614810419,"current_period_end":1646346419,"current_period_start":1614810419,"customer":"cus_J0j38qhPWapRdQ","days_until_due":null,"default_payment_method":"pm_1IR38lH8nkbB9IbKzIVmzuQP","default_source":null,"default_tax_rates":[],"discount":null,"ended_at":null,"items":{"object":"list","data":[{"id":"si_J39ScZoa98hqau","object":"subscription_item","billing_thresholds":null,"created":1614810420,"metadata":{},"plan":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"plan","active":true,"aggregate_usage":null,"amount":118800,"amount_decimal":"118800","billing_scheme":"per_unit","created":1614166258,"currency":"usd","interval":"year","interval_count":1,"livemode":false,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"price":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"price","active":true,"billing_scheme":"per_unit","created":1614166258,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":118800,"unit_amount_decimal":"118800"},"quantity":1,"subscription":"sub_J39ScO2qo7sBUN","tax_rates":[]}],"has_more":false,"total_count":1,"url":"/v1/subscription_items?subscription=sub_J39ScO2qo7sBUN"},"latest_invoice":"in_1IR39jH8nkbB9IbKFJBNYTGg","livemode":false,"metadata":{},"next_pending_invoice_item_invoice":null,"pause_collection":null,"pending_invoice_item_interval":null,"pending_setup_intent":null,"pending_update":null,"plan":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"plan","active":true,"aggregate_usage":null,"amount":118800,"amount_decimal":"118800","billing_scheme":"per_unit","created":1614166258,"currency":"usd","interval":"year","interval_count":1,"livemode":false,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":1,"schedule":null,"start_date":1614810419,"status":"active","transfer_data":null,"trial_end":null,"trial_start":null}');
-INSERT INTO payments (id,account_id,status,data) VALUES (511,211,'invalid','{"id":"sub_J39ScO2qo7sBUN","object":"subscription","application_fee_percent":null,"billing_cycle_anchor":1614810419,"billing_thresholds":null,"cancel_at":null,"cancel_at_period_end":false,"canceled_at":null,"collection_method":"charge_automatically","created":1614810419,"current_period_end":1646346419,"current_period_start":1614810419,"customer":"cus_J0j38qhPWapRdQ","days_until_due":null,"default_payment_method":"pm_1IR38lH8nkbB9IbKzIVmzuQP","default_source":null,"default_tax_rates":[],"discount":null,"ended_at":null,"items":{"object":"list","data":[{"id":"si_J39ScZoa98hqau","object":"subscription_item","billing_thresholds":null,"created":1614810420,"metadata":{},"plan":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"plan","active":true,"aggregate_usage":null,"amount":118800,"amount_decimal":"118800","billing_scheme":"per_unit","created":1614166258,"currency":"usd","interval":"year","interval_count":1,"livemode":false,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"price":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"price","active":true,"billing_scheme":"per_unit","created":1614166258,"currency":"usd","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","recurring":{"aggregate_usage":null,"interval":"year","interval_count":1,"trial_period_days":null,"usage_type":"licensed"},"tiers_mode":null,"transform_quantity":null,"type":"recurring","unit_amount":118800,"unit_amount_decimal":"118800"},"quantity":1,"subscription":"sub_J39ScO2qo7sBUN","tax_rates":[]}],"has_more":false,"total_count":1,"url":"/v1/subscription_items?subscription=sub_J39ScO2qo7sBUN"},"latest_invoice":"in_1IR39jH8nkbB9IbKFJBNYTGg","livemode":false,"metadata":{},"next_pending_invoice_item_invoice":null,"pause_collection":null,"pending_invoice_item_interval":null,"pending_setup_intent":null,"pending_update":null,"plan":{"id":"price_1IOLa2H8nkbB9IbKgGNmAyyq","object":"plan","active":true,"aggregate_usage":null,"amount":118800,"amount_decimal":"118800","billing_scheme":"per_unit","created":1614166258,"currency":"usd","interval":"year","interval_count":1,"livemode":false,"metadata":{},"nickname":null,"product":"prod_J0MIPuMEZ7pG2O","tiers_mode":null,"transform_usage":null,"trial_period_days":null,"usage_type":"licensed"},"quantity":1,"schedule":null,"start_date":1614810419,"status":"active","transfer_data":null,"trial_end":null,"trial_start":null}');
 `
 
 const existingUser = 'email=admin@uplom.com&password=password'
-const notExistingUser = 'email=nobody@uplom.com&password=password'
-const wrongPassword = 'email=admin@uplom.com&password=wrongPassword'
-const newUser = 'email=new@uplom.com&password=password'
-const noSubUser = 'email=nosub@gmail.com&password=password'
-
-const COOKIE = '__session'
+const passwordChange = 'email=admin@uplom.com&password=password&newpassword=password1&confirmation=password1'
+const passwordChangeNotMatch = 'email=admin@uplom.com&password=password&newpassword=password1&confirmation=password2'
+const passwordChangeWrongPassword = 'email=admin@uplom.com&password=wrongpassword&newpassword=password1&confirmation=password1'
 
 let agent: any
 
@@ -80,7 +67,7 @@ const configuration = (): any => ({
 // const envFile = '../env/env.local'
 // const secretsFile = '../env/secrets.local'
 
-describe('Authentication (e2e)', () => {
+describe('User (e2e)', () => {
   let app: NestExpressApplication
   // let settingsService: SettingsService
 
@@ -132,9 +119,9 @@ describe('Authentication (e2e)', () => {
         }),
         AuthModule,
         SettingsModule,
-        ValidatorModule
+        AccountsModule
       ],
-      controllers: [ApiV1AutheticationController],
+      controllers: [ApiV1AutheticationController, ApiV1UserController],
       providers: [AppService]
     }).overrideProvider(StripeService).useValue(mockedStripe).compile()
 
@@ -157,143 +144,63 @@ describe('Authentication (e2e)', () => {
     await app.close()
   })
 
-  it('login existing user with a subscription', () => {
+  // it('user password change', async () => {
+  //   return agent
+  //     .post('/api/v1/user/password-change')
+  //     .send(passwordChange)
+  //     .then(res => {
+  //       expect(res.body).toEqual({ message: {}, statusCode: 201 })
+  //     })
+  // })
+
+  it('should not allow user to change his password when password provided is wrong', done => {
     return agent
       .post('/api/v1/login')
       .send(existingUser)
       .expect(302)
-      .expect(res => {
-        const header = res.headers['set-cookie'][0]
-          .split('=')
-
-        const cookie = header[0]
-        const jwt = header[1].split(' ')[0]
-
-        expect(cookie).toBe(COOKIE)
-        expect(res.body).toEqual({ message: 'Found', redirect: 'https://app.uplom.com', statusCode: 302 })
-
-        try {
-          const { iat, ...decoded }: any = jwt_decode(jwt)
-          expect(decoded).toEqual({
-            account_id: 201,
-            account_name: '',
-            email: 'admin@uplom.com',
-            email_verified: false,
-            id: 101,
-            nonce: '',
-            staff: true,
-            status: 'active',
-            subscription_expiration: 1646346419,
-            subscription_id: 'sub_J39ScO2qo7sBUN',
-            subscription_plan: 402,
-            subscription_status: 'trialing',
-            user_email: '',
-            username: ''
-          })
-
-          return true
-        } catch (err) {
-          expect(err).toBeFalsy()
-          console.log('err', err)
-          return false
-        }
-      })
-  })
-
-  it('login existing user with an invalid subscription', () => {
-    return agent
-      .post('/api/v1/login')
-      .send(noSubUser)
-      .expect(302)
-      .expect(res => {
-        const header = res.headers['set-cookie'][0]
-          .split('=')
-
-        const cookie = header[0]
-        const jwt = header[1].split(' ')[0]
-
-        expect(cookie).toBe(COOKIE)
-        expect(res.body).toEqual({ message: 'Found', redirect: '/user/billing', statusCode: 302 })
-
-        try {
-          const { iat, ...decoded }: any = jwt_decode(jwt)
-          expect(decoded).toEqual({
-            account_id: 211,
-            account_name: '',
-            email: 'nosub@gmail.com',
-            email_verified: false,
-            id: 111,
-            nonce: '',
-            staff: false,
-            status: 'active',
-            username: ''
-          })
-
-          return true
-        } catch (err) {
-          expect(err).toBeFalsy()
-          console.log('err', err)
-          return false
-        }
-      })
-  })
-
-  it('login not existing user', () => {
-    return agent
-      .post('/api/v1/login')
-      .send(notExistingUser)
-      .expect(401)
-  })
-
-  it('login not existing user', () => {
-    return agent
-      .post('/api/v1/login')
-      .send(wrongPassword)
-      .expect(401)
-  })
-
-  it('register new user', () => {
-    return agent
-      .post('/api/v1/login')
-      .send(newUser)
-      .expect(401)
-      .then(_ =>
+      .then(res => {
         agent
-          .post('/api/v1/signup')
-          .send(newUser)
-          .expect(302)
-          .then(_ =>
-            agent
-              .post('/api/v1/login')
-              .send(newUser)
-              .expect(302)
-              .expect(res => {
-                const jwt = res.headers['set-cookie'][0]
-                  .split('=')[1]
-                  .split(' ')[0]
-                try {
-                  const decoded: any = jwt_decode(jwt)
-
-                  expect(decoded.id).toBe(112)
-                  expect(decoded.account_id).toBe(212)
-                  expect(decoded.account_name).toBe('new@uplom.com')
-                  expect(decoded.status).toBe('active')
-                  expect(decoded.email).toBe('new@uplom.com')
-                  expect(decoded.email_verified).toBe(false)
-                  expect(decoded.staff).toBe(false)
-                } catch (err) {
-                  console.log('err', err)
-                  return false
-                }
-              })
-          )
-      )
+          .post('/api/v1/user/password-change')
+          .set('Cookie', res.header['set-cookie'])
+          .send(passwordChangeWrongPassword)
+          .then(res => {
+            expect(res.body).toEqual({ error: 'Error while changing password', statusCode: 400 })
+            done()
+          })
+      })
   })
 
-  it('register existing user', () => {
+  it('should not allow user to change his password when password do not match', done => {
     return agent
-      .post('/api/v1/signup')
+      .post('/api/v1/login')
       .send(existingUser)
-      .expect(409)
+      .expect(302)
+      .then(res => {
+        agent
+          .post('/api/v1/user/password-change')
+          .set('Cookie', res.header['set-cookie'])
+          .send(passwordChangeNotMatch)
+          .then(res => {
+            expect(res.body).toEqual({ error: 'Confirmation password doesn\'t match', statusCode: 400 })
+            done()
+          })
+      })
+  })
+
+  it('should allow user to change his password', done => {
+    return agent
+      .post('/api/v1/login')
+      .send(existingUser)
+      .expect(302)
+      .then(res => {
+        agent
+          .post('/api/v1/user/password-change')
+          .set('Cookie', res.header['set-cookie'])
+          .send(passwordChange)
+          .then(res => {
+            expect(res.body).toEqual({ message: 'Password changed', statusCode: 200 })
+            done()
+          })
+      })
   })
 })

--- a/src/webapp/test/delete-user.e2e-spec.ts
+++ b/src/webapp/test/delete-user.e2e-spec.ts
@@ -32,6 +32,14 @@ import { StripeService } from '../src/payments/services/stripe.service'
  * Payments: 501 => user 101
  */
 const DB_INIT: string = `
+TRUNCATE accounts;
+TRUNCATE accounts_users;
+TRUNCATE users;
+TRUNCATE users_credentials;
+TRUNCATE plans;
+TRUNCATE payments;
+TRUNCATE settings;
+
 INSERT INTO settings VALUES (1,'website','{"name": "Uplom", "domain_primary": "uplom.com"}', NOW(), NOW());
 INSERT INTO users (id, email, password, isAdmin, isActive, emailConfirmationToken, resetPasswordToken,data) VALUES (101,'admin@uplom.com','password',1,1,1,1,'{"profile":{}}'),(102,'user@gmail.com','password',0,1,1,'1k-X4PTtCQ7lGQ','{"resetPasswordToken": "1k-X4PTtCQ7lGQ", "resetPasswordTokenExp": "1708940883080", "profile": {}}'),(111,'nosub@gmail.com','password',0,1,1,1,'{}');
 INSERT INTO accounts (id, owner_id, data) VALUES (201, 101, '{}'),(211, 111, '{}');
@@ -44,9 +52,6 @@ INSERT INTO payments (id,account_id,status,data) VALUES (501,201,'trialing','{"i
 `
 
 const existingUser = 'email=admin@uplom.com&password=password'
-const passwordChange = 'email=admin@uplom.com&password=password&newpassword=password1&confirmation=password1'
-const passwordChangeNotMatch = 'email=admin@uplom.com&password=password&newpassword=password1&confirmation=password2'
-const passwordChangeWrongPassword = 'email=admin@uplom.com&password=wrongpassword&newpassword=password1&confirmation=password1'
 
 let agent: any
 
@@ -145,54 +150,40 @@ describe('User (e2e)', () => {
   //     })
   // })
 
-  it('should not allow user to change his password when password provided is wrong', done => {
+  it('should delete a user', done => {
     return agent
       .post('/api/v1/login')
       .send(existingUser)
       .expect(302)
       .then(res => {
         agent
-          .post('/api/v1/user/password-change')
+          .delete('/api/v1/user/101')
           .set('Cookie', res.header['set-cookie'])
-          .send(passwordChangeWrongPassword)
+          .send()
           .then(res => {
-            expect(res.body).toEqual({ error: 'Error while changing password', statusCode: 400 })
-            done()
+            agent
+              .post('/api/v1/login')
+              .send(existingUser)
+              .expect(401)
+              .then(res => done())
           })
       })
   })
 
-  it('should not allow user to change his password when password do not match', done => {
-    return agent
-      .post('/api/v1/login')
-      .send(existingUser)
-      .expect(302)
-      .then(res => {
-        agent
-          .post('/api/v1/user/password-change')
-          .set('Cookie', res.header['set-cookie'])
-          .send(passwordChangeNotMatch)
-          .then(res => {
-            expect(res.body).toEqual({ error: 'Confirmation password doesn\'t match', statusCode: 400 })
-            done()
-          })
-      })
-  })
-
-  it('should allow user to change his password', done => {
-    return agent
-      .post('/api/v1/login')
-      .send(existingUser)
-      .expect(302)
-      .then(res => {
-        agent
-          .post('/api/v1/user/password-change')
-          .set('Cookie', res.header['set-cookie'])
-          .send(passwordChange)
-          .then(res => {
-            expect(res.body).toEqual({ message: 'Password changed', statusCode: 200 })
-            done()
-          })
-      })
+  it('should return an updated team list', done => {
+    // TODO when we have the user team API
+    // return agent
+    //   .post('/api/v1/login')
+    //   .send(existingUser)
+    //   .expect(302)
+    //   .then(res => {
+    //     agent
+    //       .get('/api/v1/user/team')
+    //       .set('Cookie', res.header['set-cookie'])
+    //       .send()
+    //       .then(res => {
+    //       })
+    //   })
+    done()
   })
 })


### PR DESCRIPTION
# Describe the scope of the PR

Allow to delete a user.
API + service + bare theme.

The implementation is not complete: it is still necessary to clean accountsUsers relationship for deleted users. The main problem with this task is that it should be triggered by the delete user function in the user service, but user service does not have a dependency on accounts service (and accounts has a dep on users, so it would be circular dep). We have two possible solutions:

- short term: trigger by the API that already trigger the user deletion
- long term: implement some sort of queue system that listen for user deletion

The problem is hidden and not an immediate problem: the deleted users are filtered out from the account users.

Close #110

## Add any shortcut taken

It is still necessary to clean the accountUsers relationship, see https://github.com/saasform/saasform/projects/1#card-57698092

## Tests

- [x] I manually tested
- [x] I added unit test
- [x] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
