### PR TITLE
feat: Return a better error on duplicate user creation

### DIFF
--- a/src/webapp/src/accounts/services/users.service.spec.ts
+++ b/src/webapp/src/accounts/services/users.service.spec.ts
@@ -24,6 +24,10 @@ const mockedUserCredentialsService = {
   isRegistered: jest.fn((credential, password) => credential === 'user@email.com' && password === 'password')
 }
 
+const mockValidationService = {
+  isNilOrEmpty: jest.fn().mockReturnValue(true)
+}
+
 describe('UsersService', () => {
   let service // Removed type AccountsService because we must overwrite the accountsRepository property
   let repo: Repository<UserEntity>
@@ -61,7 +65,7 @@ describe('UsersService', () => {
         },
         {
           provide: ValidationService,
-          useValue: {}
+          useValue: mockValidationService
         },
         // We must also pass TypeOrmQueryService
         TypeOrmQueryService
@@ -79,6 +83,7 @@ describe('UsersService', () => {
     service.userCredentialsService = mockedUserCredentialsService
     service.communicationService = mockedCommunicationService
     service.settingsService = mockedSettingRepo
+    service.validationService = mockValidationService
     service.random = { ...mockedRandom }
   })
 

--- a/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
+++ b/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
@@ -22,6 +22,10 @@ const mockedUserCredentialsService = {
   deleteUserCredentials: jest.fn().mockReturnValue(true)
 }
 
+const mockValidationService = {
+  isNilOrEmpty: jest.fn().mockReturnValue(true)
+}
+
 describe('UsersService Lifecycle', () => {
   let service // Removed type AccountsService because we must overwrite the accountsRepository property
   let repo: Repository<UserEntity>
@@ -59,7 +63,7 @@ describe('UsersService Lifecycle', () => {
         },
         {
           provide: ValidationService,
-          useValue: {}
+          useValue: mockValidationService
         },
         // We must also pass TypeOrmQueryService
         TypeOrmQueryService
@@ -77,6 +81,7 @@ describe('UsersService Lifecycle', () => {
     service.userCredentialsService = mockedUserCredentialsService
     service.communicationService = mockedCommunicationService
     service.settingsService = mockedSettingRepo
+    service.validationService = mockValidationService
     service.random = { ...mockedRandom }
   })
 

--- a/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
+++ b/src/webapp/src/accounts/services/users.service_lifecycle.spec.ts
@@ -14,6 +14,7 @@ import { SettingsService } from '../../settings/settings.service'
 import { PaymentsService } from '../../payments/services/payments.service'
 import { PlansService } from '../../payments/services/plans.service'
 import { ValidationService } from '../../validator/validation.service'
+import { UserError } from '../../utilities/common.model'
 
 const mockedUserCredentialsService = {
   ...mockUserCredentialsEntity,
@@ -173,6 +174,38 @@ describe('UsersService Lifecycle', () => {
       expect(userCredential?.credential).toBe(userInput.email)
       expect(userCredential.json.encryptedPassword).not.toBeUndefined()
       expect(userCredential.json.encryptedPassword).not.toBe(userInput.password)
+    })
+
+    it('should fail if duplicate email', async () => {
+      service.query = jest.fn(q => q?.filter?.email?.eq === 'foo@email.com' ? [{ user: 'mockUser' }] : [])
+      service.validationService = {
+        isNilOrEmpty: jest.fn(e => e.length === 0)
+      }
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { name: 'foo', email: 'foo@email.com', username: 'foo' }
+      }
+
+      const res = await service.addUser(userInput)
+
+      expect(res).toEqual(new UserError('duplicate_email', 'email already existing'))
+    })
+
+    it('should fail if duplicate username', async () => {
+      service.query = jest.fn(q => q?.filter?.username?.eq === 'foo' ? [{ user: 'mockUser' }] : [])
+      service.validationService = {
+        isNilOrEmpty: jest.fn(e => e.length === 0)
+      }
+      const userInput = {
+        email: 'foo@email.com',
+        password: 'password',
+        data: { name: 'foo', email: 'foo@email.com', username: 'foo' }
+      }
+
+      const res = await service.addUser(userInput)
+
+      expect(res).toEqual(new UserError('duplicate_username', 'username already existing'))
     })
   })
 

--- a/src/webapp/src/accounts/test/testData.ts
+++ b/src/webapp/src/accounts/test/testData.ts
@@ -1,7 +1,7 @@
 import { UserEntity } from '../entities/user.entity'
 import { UserCredentialsEntity } from '../entities/userCredentials.entity'
 
-const mockGenericRepo = {
+export const mockGenericRepo = {
   find: jest.fn(id => id !== 999 ? {} : undefined),
   findOne: jest.fn().mockReturnValue([{}]),
   query: jest.fn().mockReturnValue([{}]),

--- a/src/webapp/src/accounts/test/testData.ts
+++ b/src/webapp/src/accounts/test/testData.ts
@@ -16,6 +16,10 @@ export const mockAccountsUsersRepo = {
   createOne: jest.fn(accountUser => accountUser)
 }
 
+export const mockValidationService = {
+  isNilOrEmpty: jest.fn().mockReturnValue(false)
+}
+
 // TODO: refactor below this point
 
 export const mockedCommunicationService = {

--- a/src/webapp/src/api/controllers/v1/api.authentication.controller.ts
+++ b/src/webapp/src/api/controllers/v1/api.authentication.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express'
 import { SettingsService } from '../../../settings/settings.service'
 import { AuthService } from '../../../auth/auth.service'
 import { PaymentsService } from '../../../payments/services/payments.service'
+import { UserError } from '../../../utilities/common.model'
 
 @Controller('/api/v1')
 export class ApiV1AutheticationController {
@@ -88,7 +89,7 @@ export class ApiV1AutheticationController {
     }
 
     const user = await this.authService.registerUser(req.body)
-    if (user == null) {
+    if (user instanceof UserError || user == null) {
       return response.status(409).json({
         statusCode: 409,
         message: 'Already registered'

--- a/src/webapp/src/auth/interfaces/user.interface.ts
+++ b/src/webapp/src/auth/interfaces/user.interface.ts
@@ -19,7 +19,7 @@ export interface RequestUser {
   subscription_expiration?: number // timestamp
 }
 
-export interface ValidUser {
+export class ValidUser {
   user: any
   credential: any
   account: any

--- a/src/webapp/src/utilities/common.model.ts
+++ b/src/webapp/src/utilities/common.model.ts
@@ -1,0 +1,23 @@
+export enum ErrorTypes {
+  DUPLICATE_EMAIL = 'duplicate_email',
+  DUPLICATE_USERNAME = 'duplicate_username'
+}
+
+export class Err extends Error {
+  isError: true
+  type: string
+  name: ErrorTypes
+
+  constructor (name, message, type) {
+    super()
+    this.name = name
+    this.message = message
+    this.type = type
+  }
+}
+
+export class UserError extends Err {
+  constructor (name, message) {
+    super(name, message, 'UserError')
+  }
+}

--- a/src/webapp/src/validator/validation.service.spec.ts
+++ b/src/webapp/src/validator/validation.service.spec.ts
@@ -43,6 +43,10 @@ describe('ValditaionService', () => {
       expect(isNil).toBeTruthy()
     })
 
+    it('with empty array', async () => {
+      const isNil = await service.isNilOrEmpty([])
+      expect(isNil).toBeTruthy()
+    })
     it('with not empty string', async () => {
       const isNil = await service.isNilOrEmpty('something')
       expect(isNil).toBeFalsy()

--- a/src/webapp/src/validator/validation.service.ts
+++ b/src/webapp/src/validator/validation.service.ts
@@ -18,7 +18,14 @@ export class ValidationService {
     if (typeof element === 'string' && validator.isEmpty(element)) {
       return true
     }
+    if (Array.isArray(element) && element.length === 0) {
+      return true
+    }
 
     return false
+  }
+
+  isError (element): Boolean {
+    return element?.isError === true
   }
 }

--- a/src/webapp/src/website/controllers/authentication.controller.ts
+++ b/src/webapp/src/website/controllers/authentication.controller.ts
@@ -13,7 +13,8 @@ import { SettingsService } from '../../settings/settings.service'
 import { AuthService } from '../..//auth/auth.service'
 import { UsersService } from '../../accounts/services/users.service'
 import { AccountsService } from '../../accounts/services/accounts.service'
-import { PaymentsService } from 'src/payments/services/payments.service'
+import { PaymentsService } from '../../payments/services/payments.service'
+import { UserError } from '../../utilities/common.model'
 
 import { renderPage } from '../utilities/render'
 
@@ -141,11 +142,20 @@ export class AuthenticationController {
     }
 
     const user = await this.authService.registerUser(req.body)
-    if (user == null) {
+    if (user instanceof UserError || user == null) {
+      let error
+      switch (user?.name) {
+        case 'duplicate_email':
+          error = { email: 'Email already registered. Log in.' }
+          break
+        case 'duplicate_username':
+          error = { username: 'Username already registered. Log in.' }
+          break
+        default:
+          error = { email: 'Error while registering user.' }
+      }
       return renderPage(req, res, 'signup', {
-        error: {
-          email: 'User already registered. Log in.'
-        }
+        error
       })
     }
 


### PR DESCRIPTION
# Describe the scope of the PR

Return a better error on duplicate user signup.

We now can distinguish between duplicate email or duplicate username. In order to do this I have introduced a new error class called `UserError` which is returned by the `addUser` of the user service and is checked by the authservice and by the api and website controllers.

## Tests

- [x] I manually tested
- [x] I added unit test
- [ ] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
