### PR TITLE
Improve redirect after login

### DIFF
--- a/src/webapp/src/website/controllers/authentication.controller.ts
+++ b/src/webapp/src/website/controllers/authentication.controller.ts
@@ -32,18 +32,23 @@ export class AuthenticationController {
   async getNextUrl (req): Promise<string | null> {
     const baseUrl = await this.settingsService.getBaseUrl()
     const appUrl = await this.settingsService.getRedirectAfterLogin()
+    const homeUrl = await this.settingsService.getHomepageRedirectUrl()
 
     // prevent open redirects
-    const next = req.query.next
+    const next: string = req.query.next
     if (next != null) {
       if (
         // relative path
         next[0] === '/' ||
         // absolute url to Saasform
-        next.startsWith(baseUrl) === true ||
+        next.startsWith(baseUrl) ||
         // absolute url to SaaS
-        next.startsWith(appUrl) === true
+        next.startsWith(appUrl)
       ) {
+        // when home is not managed by saasform, make relative url absolute
+        if (homeUrl !== null && next[0] === '/') {
+          return `${homeUrl}${next}`
+        }
         return next
       }
     }


### PR DESCRIPTION
# Describe the scope of the PR

When Saasform redirect to SaaS-managed home, turn relative urls into absolute ones. This way it's easier for the SaaS to handle urls.

## Tests

- [x] I manually tested
- [ ] I added unit test
- [ ] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
