### PR TITLE
Fix graphql endpoint and playground (disabled by default)

### DIFF
--- a/src/webapp/src/app.module.ts
+++ b/src/webapp/src/app.module.ts
@@ -48,17 +48,12 @@ const configWebsite = (): any => yaml.load(
       }),
       inject: [ConfigService]
     }),
-    GraphQLModule.forRoot({
-      playground: true, // TODO: remove this in prod
-      installSubscriptionHandlers: true,
-      autoSchemaFile: true
-    }),
     ValidatorModule,
     SettingsModule,
 
     ScheduleModule.forRoot(),
     GraphQLModule.forRoot({
-      playground: true, // TODO: remove this in prod
+      playground: false, // to enable playground, comment out publicController::getStar
       installSubscriptionHandlers: true,
       autoSchemaFile: true
     }),

--- a/src/webapp/src/interceptors/csp.interceptor.ts
+++ b/src/webapp/src/interceptors/csp.interceptor.ts
@@ -10,6 +10,10 @@ export class CspInterceptor implements NestInterceptor {
     const res = ctx.getResponse()
     const req: any = ctx.getRequest<Request>()
 
+    if (req === undefined) {
+      return next.handle()
+    }
+
     const fixedDirectives = {
       defaultSrc: ["'self'"],
       scriptSrc: [

--- a/src/webapp/src/interceptors/jwt.interceptor.ts
+++ b/src/webapp/src/interceptors/jwt.interceptor.ts
@@ -14,6 +14,10 @@ export class JwtInterceptor implements NestInterceptor {
     const response = ctx.getResponse()
     const request: any = ctx.getRequest<Request>()
 
+    if (request === undefined) {
+      return next.handle()
+    }
+
     // TODO: improve condition
     if (request.user != null && request.user !== false) {
       await this.authService.setJwtCookie(request, response, request.user)


### PR DESCRIPTION
# Describe the scope of the PR

Fix graphql endpoint (CSRF, helmet).

For security reasons the playground is now disabled by default.

Note that the playground doesn't work with the publicController::getStar (see also [this bug](https://github.com/nestjs/graphql/issues/1485)), therefore to enable it you have to comment out the getStar (i.e. temp disable landing pages).

## Tests

- [x] I manually tested
- [ ] I added unit test
- [ ] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
