### PR TITLE
Improvements to Google Signin

### DIFF
--- a/src/themes/fresh/src/js/libs/auth/google.js
+++ b/src/themes/fresh/src/js/libs/auth/google.js
@@ -12,10 +12,7 @@ function onGoogleStart() {
 }
 
 function onGoogleSignIn(googleUser) {
-  const data = {
-    token: googleUser.getAuthResponse().id_token
-  };
-
+  const data = googleUser.getAuthResponse();
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/api/v1/google-signin');
   xhr.setRequestHeader('Content-Type', 'application/json');

--- a/src/webapp/src/auth/auth.guard.ts
+++ b/src/webapp/src/auth/auth.guard.ts
@@ -61,7 +61,7 @@ export class GoogleGuard implements CanActivate {
 
   async canActivate (context: ExecutionContext): Promise<any> {
     const req = context.switchToHttp().getRequest()
-    const profile = await this.googleService.getUserPayload(req.body.token)
+    const profile = await this.googleService.getUserPayload(req.body.id_token)
     if (profile == null || profile.email == null) {
       return false
     }

--- a/src/webapp/src/settings/settings.service.ts
+++ b/src/webapp/src/settings/settings.service.ts
@@ -658,6 +658,7 @@ export class SettingsService extends BaseService<SettingsEntity> {
     res.html_google_signin_header = res.app_google_signin_client_id !== '' && !res.app_google_signin_client_id.endsWith('xxx')
       ? `
       <meta name="google-signin-client_id" content="${res.app_google_signin_client_id}">
+      <meta name="google-signin-scope" content="${res.app_google_signin_scope}">
       <script src="https://apis.google.com/js/platform.js?onload=onGoogleStart" async defer></script>
     `
       : ''


### PR DESCRIPTION
# Describe the scope of the PR

- Add scopes
- Pass both id_token and access_token to backend

This will let us use GSuite API, for example, once a team is connected, request for admin scope and -via the access token- import all users.

_Added_

Found #200 while debugging

## Add any shortcut taken

_Ideally none_

## Tests

- [x] I manually tested
- [ ] I added unit test
- [ ] I added e2e test
- [ ] I ran the existing unit test and they do not fail
- [ ] I ran the existing e2e test and they do not fail
