### PR TITLE
Fix: signup with socials doesn't set email_verified properly

### DIFF
--- a/src/webapp/src/accounts/dto/new-user.input.ts
+++ b/src/webapp/src/accounts/dto/new-user.input.ts
@@ -8,6 +8,9 @@ export class UserJson {
 
   @Field()
   email: string
+
+  @Field()
+  emailConfirmed?: boolean = false
 };
 
 @InputType('NewUser')

--- a/src/webapp/src/accounts/services/accounts.service.ts
+++ b/src/webapp/src/accounts/services/accounts.service.ts
@@ -202,17 +202,21 @@ export class AccountsService extends BaseService<AccountEntity> {
       try {
         const res = await this.createOne(account)
         // If a user is specified add the user as owner
-        if (user !== undefined) await this.accountsUsersService.addUser(user, res)
+        if (user !== undefined) {
+          await this.accountsUsersService.addUser(user, res)
+        }
         // TODO: refactor this
 
-        // send email here (new account template)
-        const emailData = {
-          user,
-          action_url: `${await this.settingsService.getBaseUrl()}/verify-email/${user.emailConfirmationToken as string}`
-        }
+        if (user.data.emailConfirmed !== true) {
+          // send email here (new account template)
+          const emailData = {
+            user,
+            action_url: `${await this.settingsService.getBaseUrl()}/verify-email/${user.emailConfirmationToken as string}`
+          }
 
-        if ((await this.notificationService.sendEmail(user.email, 'email_confirm', emailData)) === false) {
-          console.error('Error while sending email')
+          if ((await this.notificationService.sendEmail(user.email, 'email_confirm', emailData)) === false) {
+            console.error('Error while sending email')
+          }
         }
 
         return res

--- a/src/webapp/src/accounts/services/users.service.spec.ts
+++ b/src/webapp/src/accounts/services/users.service.spec.ts
@@ -125,6 +125,24 @@ describe('UsersService', () => {
       expect(addedUser.data.emailConfirmed).toBeFalsy()
     })
 
+    it('should not set the email confirmation token and flag when a user is created', async () => {
+      const repoSpy = jest.spyOn(mockedRepo, 'createOne')
+      const userInput: NewUserInput = new NewUserInput()
+      userInput.email = 'foo@email.com'
+      userInput.password = 'password'
+      userInput.data = { name: 'foo', email: 'foo@email.com', emailConfirmed: true }
+
+      await service.addUser(userInput)
+
+      const addedUser: UserEntity = repoSpy.mock.calls[0][0]
+      expect(repoSpy).toBeCalledTimes(1)
+      // expect(addedUser.data.emailConfirmationToken).toBeNull()
+      // expect(addedUser.emailConfirmationToken).toBeNull()
+      // expect(addedUser.data.emailConfirmationTokenExp).toBeNull()
+
+      expect(addedUser.data.emailConfirmed).toBeTruthy()
+    })
+
     it('should send the confirmation email', async () => {
     })
 

--- a/src/webapp/src/accounts/services/users.service.ts
+++ b/src/webapp/src/accounts/services/users.service.ts
@@ -106,6 +106,9 @@ export class UsersService extends BaseService<UserEntity> {
     user.email = newUser.email
     user.username = newUser.data.username != null && newUser.data.username !== '' ? newUser.data.username : undefined
     user.password = (newUser.password != null) ? await bcrypt.hash(newUser.password, 12) : ''
+    for (const key in newUser.data) {
+      user.data[key] = newUser.data[key]
+    }
     const { allowedKeys } = await this.settingsService.getUserSettings()
     allowedKeys.forEach(
       key => {

--- a/src/webapp/test/authentication.e2e-spec.ts
+++ b/src/webapp/test/authentication.e2e-spec.ts
@@ -310,35 +310,35 @@ describe('Authentication (e2e)', () => {
   it('with a registered google credential for a registered user, should signin into saasform IF email is verified', () => {
     return agent
       .post('/api/v1/google-signin')
-      .send(`token=${GOOGLE_ID_TOKEN_TO_SIGNIN}`)
-      .expect(302)
+      .send(`id_token=${GOOGLE_ID_TOKEN_TO_SIGNIN}`)
+      .expect(302, '{"statusCode":302,"message":"Found","redirect":"https://app.uplom.com"}')
   })
 
   it('with a registered google credential for a registered user, should NOT signin into saasform IF saasform email unverified', () => {
     return agent
       .post('/api/v1/google-signin')
-      .send(`token=${GOOGLE_ID_TOKEN_TO_UNVERIFIED}`)
+      .send(`id_token=${GOOGLE_ID_TOKEN_TO_UNVERIFIED}`)
       .expect(409)
   })
 
   it('with a registered google credential for a registered user, should NOT signin into saasform IF google email unverified', () => {
     return agent
       .post('/api/v1/google-signin')
-      .send(`token=${GOOGLE_ID_TOKEN_UNVERIFIED_ON_GOOGLE}`)
+      .send(`id_token=${GOOGLE_ID_TOKEN_UNVERIFIED_ON_GOOGLE}`)
       .expect(409)
   })
 
   it('with a not registered google credential for a registered user, should signup into saasform and redirect into saasform', () => {
     return agent
       .post('/api/v1/google-signin')
-      .send(`token=${GOOGLE_ID_TOKEN_TO_SIGNUP}`)
-      .expect(302)
+      .send(`id_token=${GOOGLE_ID_TOKEN_TO_SIGNUP}`)
+      .expect(302, '{"statusCode":302,"message":"Found","redirect":"https://app.uplom.com"}')
   })
 
   it('with a not registered google credential for a not registered user, should signup into saasform and redirect into saasform', () => {
     return agent
       .post('/api/v1/google-signin')
-      .send(`token=${GOOGLE_ID_TOKEN_TO_ERROR}`)
-      .expect(302)
+      .send(`id_token=${GOOGLE_ID_TOKEN_TO_ERROR}`)
+      .expect(302, '{"statusCode":302,"message":"Found","redirect":"https://app.uplom.com"}')
   })
 })


### PR DESCRIPTION
# Describe the scope of the PR

Fix signup with socials doesn't set email_verified properly. The field was not correctly copied into the new user model.

_Solved_

Fix #200

## Tests

- [x] I manually tested
- [x] I added unit test
- [x] I added e2e test
- [x] I ran the existing unit test and they do not fail
- [x] I ran the existing e2e test and they do not fail
