### PR TITLE
Okta single sign-on

### DIFF
--- a/src/webapp/src/accounts/services/accounts.service.ts
+++ b/src/webapp/src/accounts/services/accounts.service.ts
@@ -79,15 +79,12 @@ export class AccountsService extends BaseService<AccountEntity> {
   }
 
   /**
-   * Return the account that is linked to an email domain, if it exists. Null otherwise.
-   * For instance if a company links the domain "@company.com" every email @company.com
-   * will return the company account
+   * Return the account that is linked to a domain, if it exists. Null otherwise.
    *
-   * @param email an email to search
+   * @param domain to search
    * @returns the account or null
    */
-  async getAccountByEmailDomain (email: string): Promise<AccountEntity|null> {
-    const domain = email.split('@')[1]
+  async getAccountByDomain (domain: string): Promise<AccountEntity|null> {
     const accountId = await this.accountsDomainsService.getAccountIsByEmailDomain(domain)
     if (accountId == null) {
       // console.log('accountsService - getAccountByEmailDomain - cannot find account for the domain', domain)
@@ -103,6 +100,19 @@ export class AccountsService extends BaseService<AccountEntity> {
     }
 
     return account ?? null
+  }
+
+  /**
+   * Return the account that is linked to an email domain, if it exists. Null otherwise.
+   * For instance if a company links the domain "@company.com" every email @company.com
+   * will return the company account
+   *
+   * @param email an email to search
+   * @returns the account or null
+   */
+  async getAccountByEmailDomain (email: string): Promise<AccountEntity|null> {
+    const domain = email.split('@')[1]
+    return await this.getAccountByDomain(domain)
   }
 
   /**

--- a/src/webapp/src/auth/auth.guard.ts
+++ b/src/webapp/src/auth/auth.guard.ts
@@ -83,4 +83,7 @@ export class AzureAdGuard extends AuthGuard('azuread-openidconnect') {}
 export class MiraclGuard extends AuthGuard('miracl') {}
 
 @Injectable()
+export class OktaGuard extends AuthGuard('okta') {}
+
+@Injectable()
 export class BearerTokenGuard extends AuthGuard('bearer') {}

--- a/src/webapp/src/auth/auth.module.ts
+++ b/src/webapp/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { LocalStrategy } from './local.strategy'
 import { JwtStrategy } from './jwt.strategy'
 import { AzureAdStrategy } from './azuread.strategy'
 import { MiraclStrategy } from './miracl.strategy'
+import { OktaStrategy } from './okta.strategy'
 import { JwtModule } from '@nestjs/jwt'
 import { AccountsModule } from '../accounts/accounts.module'
 import { SettingsService } from '../settings/settings.service'
@@ -35,6 +36,7 @@ import { BearerTokenStrategy } from './bearertoken.strategy'
     GoogleOAuth2Service,
     AzureAdStrategy,
     MiraclStrategy,
+    OktaStrategy,
     BearerTokenStrategy
   ],
   exports: [AuthService, GoogleOAuth2Service, JwtModule]

--- a/src/webapp/src/auth/auth.service.ts
+++ b/src/webapp/src/auth/auth.service.ts
@@ -228,6 +228,12 @@ export class AuthService {
     return email != null ? user : null
   }
 
+  async getOrgByDomain (domain: string): Promise<any> {
+    const account = await this.accountsService.getAccountByDomain(domain)
+    const org = account?.data?.org ?? null
+    return org
+  }
+
   async createNewUser (newUser: any): Promise<ValidUser | UserError | null> {
     const { email } = newUser
     if (email == null) {
@@ -474,6 +480,38 @@ export class AuthService {
       subject: profile.id,
       extra,
       tokens: { access_token: accessToken, refresh_token: refreshToken }
+    })
+  }
+
+  async authOkta (req, profile, accessToken, refreshToken): Promise<RequestUser | null> {
+    /*
+      profile = {
+        id: '00uc4l9dEVFyEGY9F695',
+        displayName: 'Emanuele Due',
+        name: { familyName: 'Due', givenName: 'Emanuele', middleName: undefined },
+        _raw: '{"sub":"00uc4l9dEVFyEGY9F695","name":"Emanuele Due","locale":"en-US","email":"ec@saasform.dev","preferred_username":"ec@saasform.dev","given_name":"Emanuele","family_name":"Due","zoneinfo":"America/Los_Angeles","updated_at":1626335424,"email_verified":true}',
+        _json: {
+          sub: '00uc4l9dEVFyEGY9F695',
+          name: 'Emanuele Due',
+          locale: 'en-US',
+          email: 'ec@saasform.dev',
+          preferred_username: 'ec@saasform.dev',
+          given_name: 'Emanuele',
+          family_name: 'Due',
+          zoneinfo: 'America/Los_Angeles',
+          updated_at: 1626335424,
+          email_verified: true
+        }
+    */
+    const data = profile?._json ?? {}
+    const { _raw, ...extra } = profile
+
+    return await this.userFindOrCreate(req, {
+      provider: 'okta',
+      email: data.email,
+      email_verified: data.email_verified ?? false,
+      subject: profile.id,
+      extra
     })
   }
 }

--- a/src/webapp/src/auth/okta.strategy.ts
+++ b/src/webapp/src/auth/okta.strategy.ts
@@ -1,0 +1,84 @@
+import { Strategy } from 'passport-oauth2-oidc'
+import { PassportStrategy } from '@nestjs/passport'
+import { ContextIdFactory, ModuleRef } from '@nestjs/core'
+
+import { Injectable } from '@nestjs/common'
+import { AuthService } from './auth.service'
+import { SettingsService } from '../settings/settings.service'
+import { RequestUser } from './interfaces/user.interface'
+
+async function getOptionsFromReq (req, done): Promise<any> {
+  const contextId = ContextIdFactory.getByRequest(req)
+  const authService = await this.moduleRef.resolve(AuthService, contextId)
+  const settingsService = await this.moduleRef.resolve(SettingsService, contextId)
+
+  const issuer = req.query?.iss ?? null
+  if (issuer == null) {
+    return {}
+  }
+
+  let domain
+  try {
+    domain = (new URL(issuer)).hostname
+  } catch (TypeError) {
+    domain = null
+    return {}
+  }
+  if (domain == null) {
+    return {}
+  }
+
+  const org = await authService.getOrgByDomain(domain)
+  if (org == null) {
+    return {}
+  }
+
+  const baseUrl: string = await settingsService.getBaseUrl()
+  const orgDomain: string = `https://${org.domain as string}` // this should be the same as issuer, but forces https and prevents injections
+
+  return {
+    passReqToCallback: true,
+    verifyArity: 9,
+
+    issuer: orgDomain,
+    authorizationURL: `${orgDomain}/oauth2/v1/authorize`,
+    tokenURL: `${orgDomain}/oauth2/v1/token`,
+    userInfoURL: `${orgDomain}/oauth2/v1/userinfo`,
+
+    scope: 'openid profile email phone groups',
+    clientID: org.client_id,
+    clientSecret: org.client_secret,
+    callbackURL: `${baseUrl}/auth/okta/callback`
+  }
+}
+
+@Injectable()
+export class OktaStrategy extends PassportStrategy(Strategy, 'okta') {
+  constructor (private readonly moduleRef: ModuleRef) {
+    super({
+      passReqToCallback: true,
+      verifyArity: 9,
+      getOptionsFromReq,
+
+      issuer: 'https://theneeds.okta.com',
+      authorizationURL: 'https://theneeds.okta.com/oauth2/v1/authorize',
+      tokenURL: 'https://theneeds.okta.com/oauth2/v1/token',
+      userInfoURL: 'https://theneeds.okta.com/oauth2/v1/userinfo',
+
+      scope: 'openid profile email phone groups',
+      clientID: '...',
+      clientSecret: '...'
+      // callbackURL: '/auth/okta/callback',
+    })
+  }
+
+  async validate (
+    req, iss, sub, profile, jwtClaims, accessToken, refreshToken, params
+  ): Promise<RequestUser | null> {
+    const contextId = ContextIdFactory.getByRequest(req)
+    const authService = await this.moduleRef.resolve(AuthService, contextId)
+
+    const requestUser = await authService.authOkta(req, profile, accessToken, refreshToken)
+    return requestUser
+  }
+}

--- a/src/webapp/src/filters/http-exceptions.filter.ts
+++ b/src/webapp/src/filters/http-exceptions.filter.ts
@@ -107,7 +107,7 @@ export class HttpExceptionsFilter implements ExceptionFilter {
             next = originalUrl
           }
 
-          if (next != null && next !== '') {
+          if (next != null && next !== '' && !next.startsWith('/auth/')) {
             response.redirect(`/login?next=${next}`)
           } else {
             response.redirect('/login')

--- a/src/webapp/src/website/controllers/authentication.controller.ts
+++ b/src/webapp/src/website/controllers/authentication.controller.ts
@@ -8,7 +8,7 @@ import {
   Param
 } from '@nestjs/common'
 import { Response } from 'express'
-import { UserOptionalAuthGuard, AzureAdGuard, MiraclGuard } from '../..//auth/auth.guard'
+import { UserOptionalAuthGuard, AzureAdGuard, MiraclGuard, OktaGuard } from '../..//auth/auth.guard'
 import { SettingsService } from '../../settings/settings.service'
 import { AuthService } from '../..//auth/auth.service'
 import { UsersService } from '../../accounts/services/users.service'
@@ -262,6 +262,21 @@ export class AuthenticationController {
   @UseGuards(MiraclGuard)
   @Get('/auth/miracl/callback')
   async miraclReturnFrom (@Request() req, @Res() res: Response): Promise<any> {
+    if (req.user !== false) {
+      const redirect = await this.settingsService.getActualRedirectAfterLogin(req.user, req.query.next)
+      return res.redirect(redirect)
+    }
+    return res.redirect('/login')
+  }
+
+  @UseGuards(OktaGuard)
+  @Get('/auth/okta')
+  async oktaRedirectTo (@Request() req, @Res() res: Response): Promise<any> {
+  }
+
+  @UseGuards(OktaGuard)
+  @Get('/auth/okta/callback')
+  async oktaReturnFrom (@Request() req, @Res() res: Response): Promise<any> {
     if (req.user !== false) {
       const redirect = await this.settingsService.getActualRedirectAfterLogin(req.user, req.query.next)
       return res.redirect(redirect)


### PR DESCRIPTION
# Describe the scope of the PR

Add SSO via Okta. This PR adds all necessary authentication when the login flow starts from Okta.

Need to add user-initiated flow from our login page.

## Tests

- [x] I manually tested
- [ ] I added unit test
- [ ] I added e2e test
- [ ] I ran the existing unit test and they do not fail
- [ ] I ran the existing e2e test and they do not fail
