### PR TITLE
Fresh/SSO: display logged in user in home

### DIFF
--- a/data/themes/fresh-sso/index.liquid
+++ b/data/themes/fresh-sso/index.liquid
@@ -27,7 +27,7 @@
   <section class="hero is-fullheight">
     <div class="hero-body">
       <div class="container">
-        <div class="columns is-centered ">
+        <div class="columns is-centered is-vcentered">
           <div class="column is-half">
             <div class="content">
   
@@ -47,7 +47,26 @@
           </div>
           <div class="column is-one-third">
   
+          {% if user.email %}
+          <div class="is-flex is-flex-direction-column is-justify-content-space-between" style="min-height: 600px;">
+            <div>
+              {{ user.email }} (<a href="/logout">logout</a>)
+            </div>
   
+            <div>
+              <a href="{{ saas_redirect_url }}" class="button is-primary is-medium raised">
+                Dashboard&nbsp;&nbsp;
+                <span class="icon is-small">
+                  <i class="fa fa-arrow-right"></i>
+                </span>
+              </a>
+            </div>
+  
+            <div>
+              &nbsp;
+            </div>
+          </div>
+          {% else %}
           <!-- Form -->
           <form action="/login" method="POST" class="mb-40">
   
@@ -144,6 +163,7 @@
           <p class="is-size-7 has-text-grey has-text-centered">
             Don't have an account yet? <a href="/signup{% if next_url %}?next={{ next_url | url_encode }}{% endif %}">Sign up</a>.
           </p>
+          {% endif %}
   
         </div>
         </div>

--- a/data/themes/fresh-sso/login.liquid
+++ b/data/themes/fresh-sso/login.liquid
@@ -27,7 +27,7 @@
   <section class="hero is-fullheight">
     <div class="hero-body">
       <div class="container">
-        <div class="columns is-centered ">
+        <div class="columns is-centered is-vcentered">
           <div class="column is-half">
             <div class="content">
   
@@ -47,7 +47,26 @@
           </div>
           <div class="column is-one-third">
   
+          {% if user.email %}
+          <div class="is-flex is-flex-direction-column is-justify-content-space-between" style="min-height: 600px;">
+            <div>
+              {{ user.email }} (<a href="/logout">logout</a>)
+            </div>
   
+            <div>
+              <a href="{{ saas_redirect_url }}" class="button is-primary is-medium raised">
+                Dashboard&nbsp;&nbsp;
+                <span class="icon is-small">
+                  <i class="fa fa-arrow-right"></i>
+                </span>
+              </a>
+            </div>
+  
+            <div>
+              &nbsp;
+            </div>
+          </div>
+          {% else %}
           <!-- Form -->
           <form action="/login" method="POST" class="mb-40">
   
@@ -144,6 +163,7 @@
           <p class="is-size-7 has-text-grey has-text-centered">
             Don't have an account yet? <a href="/signup{% if next_url %}?next={{ next_url | url_encode }}{% endif %}">Sign up</a>.
           </p>
+          {% endif %}
   
         </div>
         </div>

--- a/src/themes/fresh/src/pages/index-sso.html
+++ b/src/themes/fresh/src/pages/index-sso.html
@@ -4,7 +4,7 @@ layout: default
 <section class="hero is-fullheight">
   <div class="hero-body">
     <div class="container">
-      <div class="columns is-centered ">
+      <div class="columns is-centered is-vcentered">
         <div class="column is-half">
           <div class="content">
 
@@ -24,7 +24,26 @@ layout: default
         </div>
         <div class="column is-one-third">
 
+        {% if user.email %}
+        <div class="is-flex is-flex-direction-column is-justify-content-space-between" style="min-height: 600px;">
+          <div>
+            {{ user.email }} (<a href="/logout">logout</a>)
+          </div>
 
+          <div>
+            <a href="{{ website.saas_redirect_url }}" class="button is-primary is-medium raised">
+              Dashboard&nbsp;&nbsp;
+              <span class="icon is-small">
+                <i class="fa fa-arrow-right"></i>
+              </span>
+            </a>
+          </div>
+
+          <div>
+            &nbsp;
+          </div>
+        </div>
+        {% else %}
         <!-- Form -->
         <form action="/login" method="POST" class="mb-40">
 
@@ -121,6 +140,7 @@ layout: default
         <p class="is-size-7 has-text-grey has-text-centered">
           Don't have an account yet? <a href="/signup{% if next_url %}?next={{ website.next_url }}{% endif %}">Sign up</a>.
         </p>
+        {% endif %}
 
       </div>
       </div>


### PR DESCRIPTION
# Describe the scope of the PR

There fresh-sso didn't show anything when user is logged in.

Before
<img width="455" alt="Screen Shot 2021-07-22 at 10 08 30 AM" src="https://user-images.githubusercontent.com/1491992/126608036-0440a492-37ec-4ff9-9450-5c4572acf9f6.png">

After
<img width="448" alt="Screen Shot 2021-07-22 at 10 08 37 AM" src="https://user-images.githubusercontent.com/1491992/126608061-3a1fdb99-6742-4363-9dc3-55a6121f07fd.png">


## Tests

- [x] I manually tested
- [ ] I added unit test
- [ ] I added e2e test
- [ ] I ran the existing unit test and they do not fail
- [ ] I ran the existing e2e test and they do not fail
