### PR TITLE
Okta: enforce org provider and login starting from Saasform

### DIFF
--- a/data/themes/fresh-sso/index.liquid
+++ b/data/themes/fresh-sso/index.liquid
@@ -79,21 +79,22 @@
                 <input type="email" class="input" id="email" name="email" placeholder="name@address.com" required>
               </div>
               <p id="error-email" class="help is-danger">{{ error.email | formatDot }}</p>
+              <p id="error-password" class="help is-danger">{{ error.password | formatDot }}</p>
             </div>
   
             <!-- Password -->
-            <div class="field">
+            <!--div class="field">
               <label for="password" class="label has-text-weight-normal">
                 Password
               </label>
               <div class="control has-icons-right">
-                <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password" required>
+                <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password">
                 <span class="icon is-small is-right" style="pointer-events: auto" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; document.getElementById('fa-eye').classList.toggle(isPass ? 'fa-eye-slash' : 'fa-eye');">
                   <i id="fa-eye" class="fa fa-eye"></i>
                 </span>
               </div>
               <p id="error-password" class="help is-danger">{{ error.password | formatDot }}</p>
-            </div>
+            </div-->
   
             <!-- Submit -->
             <input type="hidden" name="_csrf" value="{{ csrf_token }}">

--- a/data/themes/fresh-sso/login.liquid
+++ b/data/themes/fresh-sso/login.liquid
@@ -79,21 +79,22 @@
                 <input type="email" class="input" id="email" name="email" placeholder="name@address.com" required>
               </div>
               <p id="error-email" class="help is-danger">{{ error.email | formatDot }}</p>
+              <p id="error-password" class="help is-danger">{{ error.password | formatDot }}</p>
             </div>
   
             <!-- Password -->
-            <div class="field">
+            <!--div class="field">
               <label for="password" class="label has-text-weight-normal">
                 Password
               </label>
               <div class="control has-icons-right">
-                <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password" required>
+                <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password">
                 <span class="icon is-small is-right" style="pointer-events: auto" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; document.getElementById('fa-eye').classList.toggle(isPass ? 'fa-eye-slash' : 'fa-eye');">
                   <i id="fa-eye" class="fa fa-eye"></i>
                 </span>
               </div>
               <p id="error-password" class="help is-danger">{{ error.password | formatDot }}</p>
-            </div>
+            </div-->
   
             <!-- Submit -->
             <input type="hidden" name="_csrf" value="{{ csrf_token }}">

--- a/src/themes/fresh/src/pages/index-sso.html
+++ b/src/themes/fresh/src/pages/index-sso.html
@@ -56,21 +56,22 @@ layout: default
               <input type="email" class="input" id="email" name="email" placeholder="name@address.com" required>
             </div>
             <p id="error-email" class="help is-danger">{{ error.email }}</p>
+            <p id="error-password" class="help is-danger">{{ error.password }}</p>
           </div>
 
           <!-- Password -->
-          <div class="field">
+          <!--div class="field">
             <label for="password" class="label has-text-weight-normal">
               Password
             </label>
             <div class="control has-icons-right">
-              <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password" required>
+              <input type="password" class="input" id="password" name="password" placeholder="Enter your password" minlength="8" autocomplete="new-password">
               <span class="icon is-small is-right" style="pointer-events: auto" onclick="const p = document.getElementById('password'); const isPass = p.type === 'password'; p.type = isPass ? 'text' : 'password'; document.getElementById('fa-eye').classList.toggle(isPass ? 'fa-eye-slash' : 'fa-eye');">
                 <i id="fa-eye" class="fa fa-eye"></i>
               </span>
             </div>
             <p id="error-password" class="help is-danger">{{ error.password }}</p>
-          </div>
+          </div-->
 
           <!-- Submit -->
           <input type="hidden" name="_csrf" value="{{ website.csrf_token }}">

--- a/src/webapp/src/accounts/entities/userCredentials.entity.ts
+++ b/src/webapp/src/accounts/entities/userCredentials.entity.ts
@@ -60,12 +60,13 @@ export class UserCredentialsEntity {
     this.json[provider] = this.json[provider] ?? {}
     this[provider] = this[provider] ?? {}
     const providerTokens = this[provider].tokens ?? {}
+    const inputTokens = tokens ?? {}
 
     // The refresh token is usually only is sent at the first login
     // If refresh_token is provided save it, otherwise it does not overwrite
     this[provider].tokens = this.json[provider].tokens = {
-      access_token: tokens.access_token ?? providerTokens.access_token,
-      refresh_token: tokens.refresh_token ?? providerTokens.refresh_token
+      access_token: inputTokens.access_token ?? providerTokens.access_token,
+      refresh_token: inputTokens.refresh_token ?? providerTokens.refresh_token
     }
   }
 

--- a/src/webapp/src/accounts/services/userCredentials.service.ts
+++ b/src/webapp/src/accounts/services/userCredentials.service.ts
@@ -53,7 +53,7 @@ export class UserCredentialsService extends BaseService<UserCredentialsEntity> {
   }
 
   isRegistered (userCredentials: UserCredentialsEntity, password: string): boolean {
-    if (userCredentials == null || password == null) {
+    if (userCredentials == null || password == null || password === '') {
       return false
     }
 

--- a/src/webapp/src/auth/auth.guard.ts
+++ b/src/webapp/src/auth/auth.guard.ts
@@ -68,9 +68,15 @@ export class GoogleGuard implements CanActivate {
 
     const accessToken = req?.body?.access_token ?? ''
 
-    const { refresh_token } = await this.googleService.getRefreshToken(req.body.code) // eslint-disable-line
+    let refreshToken
+    try {
+      const tokens = await this.googleService.getOAuthTokens(req.body.code)
+      refreshToken = tokens.refresh_token
+    } catch (_) {
+      // pass
+    }
 
-    const requestUser = await this.authService.authGoogle(req, profile, accessToken, refresh_token)
+    const requestUser = await this.authService.authGoogle(req, profile, accessToken, refreshToken)
     req.user = requestUser
 
     return true

--- a/src/webapp/src/auth/auth.service.spec.ts
+++ b/src/webapp/src/auth/auth.service.spec.ts
@@ -12,7 +12,9 @@ import { PlansService } from '../payments/services/plans.service'
 import { UserError, ErrorTypes } from '../utilities/common.model'
 
 const mockJwtService = {}
-const mockAccountsService = {}
+const mockAccountsService = {
+  getAccountByDomain: async (domain) => (null)
+}
 const mockPaymentsService = {
   getPaymentsConfig: async () => ({}),
   refreshPaymentsFromStripe: async () => {},

--- a/src/webapp/src/auth/google.service.ts
+++ b/src/webapp/src/auth/google.service.ts
@@ -17,7 +17,7 @@ export class GoogleOAuth2Service {
     return payload
   }
 
-  async getRefreshToken (code: string): Promise<any> {
+  async getOAuthTokens (code: string): Promise<any> {
     const { clientID, clientSecret, redirectURI } = await this.settingsService.getGoogleStrategyConfig()
 
     if (clientSecret != null && clientSecret !== '' && code != null && code !== '') {

--- a/src/webapp/src/filters/http-exceptions.filter.ts
+++ b/src/webapp/src/filters/http-exceptions.filter.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common'
 import { Request, Response } from 'express'
 import { saasformReporter, tags } from '../utilities/reporting'
+import { UnauthorizedWithRedirectException } from '../auth/auth.service'
 
 @Catch()
 export class HttpExceptionsFilter implements ExceptionFilter {
@@ -28,6 +29,10 @@ export class HttpExceptionsFilter implements ExceptionFilter {
 
     console.error('HttpExceptionsFilter - received exception', exception)
     saasformReporter.errorReport(exception, tags, true).then(() => {}, () => {})
+
+    if (exception instanceof UnauthorizedWithRedirectException) {
+      return response.redirect(exception.redirect)
+    }
 
     if (requestAccept != null && requestAccept === 'application/json') {
       if (exception instanceof UnauthorizedException) {

--- a/src/webapp/src/settings/settings.service.ts
+++ b/src/webapp/src/settings/settings.service.ts
@@ -224,7 +224,7 @@ export class SettingsService extends BaseService<SettingsEntity> {
     return (clientID !== '' && !clientID.endsWith('xxx')) ? {
       clientID,
       clientSecret,
-      redirectURI: `${baseUrl}/auth/google/callback`
+      redirectURI: baseUrl
     } : null
   }
 

--- a/src/webapp/src/website/controllers/authentication.controller.ts
+++ b/src/webapp/src/website/controllers/authentication.controller.ts
@@ -61,24 +61,18 @@ export class AuthenticationController {
     if (email == null) {
       return renderPage(req, res, 'login', {
         error: {
-          email: 'Email not valid.'
+          email: 'Invalid email or password.'
         }
       })
     }
 
-    if (password == null) {
-      return renderPage(req, res, 'login', {
-        error: {
-          password: 'Password not valid.'
-        }
-      })
-    }
+    // we support null password as we may return redirect to SSO, e.g. Okta
 
     const user = await this.authService.validateUser(email, password)
     if (user == null) {
       return renderPage(req, res, 'login', {
         error: {
-          password: 'Invalid username or password'
+          password: 'Invalid email or password'
         }
       })
     }
@@ -103,7 +97,7 @@ export class AuthenticationController {
     if (email == null) {
       return renderPage(req, res, 'signup', {
         error: {
-          email: 'Email not valid.'
+          email: 'Invalid email.'
         }
       })
     }
@@ -111,7 +105,7 @@ export class AuthenticationController {
     if (password == null) {
       return renderPage(req, res, 'signup', {
         error: {
-          password: 'Password not valid.'
+          password: 'Invalid password.'
         }
       })
     }
@@ -220,7 +214,7 @@ export class AuthenticationController {
     let error
     if (password == null) {
       error = {
-        password: 'Password not valid.'
+        password: 'Invalid password.'
       }
       return renderPage(req, res, 'password-change', { token, error })
     }


### PR DESCRIPTION
# Describe the scope of the PR

Login with Okta
1. From Okta as an OIDC app
2. From Saasform (user enters email), redirect to Okta

New auth flow that enforces organization/provider.

## Tests

- [x] I manually tested
- [x] I added unit test
- [x] I added e2e test
- [ ] I ran the existing unit test and they do not fail
- [ ] I ran the existing e2e test and they do not fail
